### PR TITLE
fix: media_asset 도메인 수정사항. presign 소유자/권한 검증 강화

### DIFF
--- a/backend/src/main/java/org/example/backend/media_asset/controller/MediaAssetController.java
+++ b/backend/src/main/java/org/example/backend/media_asset/controller/MediaAssetController.java
@@ -2,12 +2,14 @@ package org.example.backend.media_asset.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.backend.global.security.details.PrincipalDetails;
 import org.example.backend.media_asset.dto.request.CompleteRequest;
 import org.example.backend.media_asset.dto.request.PresignRequest;
 import org.example.backend.media_asset.dto.response.CompleteResponse;
 import org.example.backend.media_asset.dto.response.PresignResponse;
 import org.example.backend.media_asset.service.MediaAssetService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,13 +24,15 @@ public class MediaAssetController {
 
     // 업로드 요청 배치를 받아 presigned PUT URL을 발급한다.
     @PostMapping("/presign")
-    public ResponseEntity<PresignResponse> presign(@Valid @RequestBody PresignRequest request) {
-        return ResponseEntity.ok(mediaAssetService.presign(request));
+    public ResponseEntity<PresignResponse> presign(@Valid @RequestBody PresignRequest request,
+                                                   @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ResponseEntity.ok(mediaAssetService.presign(request, principalDetails));
     }
 
     // 업로드 완료 후 objectKey 목록을 받아 S3 HEAD 검증을 수행한다.
     @PostMapping("/complete")
-    public ResponseEntity<CompleteResponse> complete(@Valid @RequestBody CompleteRequest request) {
-        return ResponseEntity.ok(mediaAssetService.complete(request));
+    public ResponseEntity<CompleteResponse> complete(@Valid @RequestBody CompleteRequest request,
+                                                     @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ResponseEntity.ok(mediaAssetService.complete(request, principalDetails));
     }
 }

--- a/backend/src/main/java/org/example/backend/media_asset/dto/request/PresignItemRequest.java
+++ b/backend/src/main/java/org/example/backend/media_asset/dto/request/PresignItemRequest.java
@@ -4,14 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.example.backend.media_asset.entity.MediaAssetCategory;
 import org.example.backend.media_asset.entity.MediaAssetScope;
-import org.example.backend.user.enums.UserRole;
 
 // presign 단건 요청에 필요한 메타데이터를 담는 DTO
 public record PresignItemRequest(
-        @NotNull
-        Long ownerUserId,
-        @NotNull
-        UserRole userRole,
         @NotNull
         MediaAssetCategory category,
         @NotNull

--- a/backend/src/main/java/org/example/backend/media_asset/service/MediaAssetService.java
+++ b/backend/src/main/java/org/example/backend/media_asset/service/MediaAssetService.java
@@ -1,6 +1,7 @@
 package org.example.backend.media_asset.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.backend.global.security.details.PrincipalDetails;
 import org.example.backend.media_asset.config.AwsProperties;
 import org.example.backend.media_asset.config.MediaProperties;
 import org.example.backend.media_asset.dto.request.CompleteRequest;
@@ -20,6 +21,7 @@ import org.example.backend.media_asset.metadata.VideoMetadataExtractor;
 import org.example.backend.media_asset.repository.MediaAssetRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.example.backend.user.enums.UserRole;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -45,11 +47,13 @@ public class MediaAssetService {
 
     // 업로드용 presigned URL을 배치 발급하고 INITIATED 상태를 저장한다.
     @Transactional
-    public PresignResponse presign(PresignRequest request) {
+    public PresignResponse presign(PresignRequest request, PrincipalDetails principalDetails) {
+        Long userId = principalDetails.getUserId();
+        UserRole userRole = principalDetails.getUser().getRole();
         List<PresignItemResponse> responses = new ArrayList<>();
         for (PresignItemRequest item : request.items()) {
-            mediaPolicyValidator.validatePresign(item);
-            String objectKey = objectKeyGenerator.generate(item);
+            mediaPolicyValidator.validatePresign(item, userRole);
+            String objectKey = objectKeyGenerator.generate(item, userId);
             if (mediaAssetRepository.findByObjectKey(objectKey).isPresent()) {
                 throw new MediaAssetException(MediaAssetErrorCode.DUPLICATE_MEDIA_ASSET);
             }
@@ -64,7 +68,7 @@ public class MediaAssetService {
             );
 
             MediaAsset mediaAsset = new MediaAsset(
-                    item.ownerUserId(),
+                    userId,
                     item.category(),
                     item.scope(),
                     objectKey,
@@ -88,7 +92,8 @@ public class MediaAssetService {
 
     // 업로드 완료 배치를 처리해 S3 HEAD 검증 후 상태를 확정한다.
     @Transactional
-    public CompleteResponse complete(CompleteRequest request) {
+    public CompleteResponse complete(CompleteRequest request, PrincipalDetails principalDetails) {
+        Long userId = principalDetails.getUserId();
         List<CompleteItemResponse> responses = new ArrayList<>();
         for (var item : request.items()) {
             String objectKey = item.objectKey();
@@ -122,6 +127,19 @@ public class MediaAssetService {
             }
 
             MediaAsset mediaAsset = optionalMediaAsset.get();
+            if (!mediaAsset.getOwnerUserId().equals(userId)) {
+                responses.add(new CompleteItemResponse(
+                        mediaAsset.getId(),
+                        mediaAsset.getObjectKey(),
+                        MediaAssetStatus.REJECTED,
+                        null,
+                        null,
+                        null,
+                        null,
+                        MediaAssetErrorCode.MEDIA_ASSET_ACCESS_DENIED.getCode()
+                ));
+                continue;
+            }
             LocalDateTime now = LocalDateTime.now(mediaClock);
             if (mediaAsset.getStatus() == MediaAssetStatus.INITIATED
                     && mediaAsset.getExpiresAt() != null
@@ -188,6 +206,7 @@ public class MediaAssetService {
         return new CompleteResponse(responses);
     }
 
+    // presign 요청의 owner/userRole이 로그인 사용자와 일치하는지 확인한다.
     // HEAD 결과가 정책/요청값과 일치하는지 검사하고 거부 사유를 리턴한다.
     private MediaAssetRejectedReason validateHead(MediaAsset mediaAsset, String actualContentType, long actualSizeBytes) {
         if (!mediaPolicyValidator.isContentTypeAllowed(mediaAsset.getCategory(), actualContentType)) {

--- a/backend/src/main/java/org/example/backend/media_asset/service/MediaPolicyValidator.java
+++ b/backend/src/main/java/org/example/backend/media_asset/service/MediaPolicyValidator.java
@@ -32,9 +32,9 @@ public class MediaPolicyValidator {
     }
 
     // Presign 요청의 전체 정책(권한/타입/용량/길이/첨부)을 검증한다.
-    public void validatePresign(PresignItemRequest item) {
+    public void validatePresign(PresignItemRequest item, UserRole userRole) {
         String normalizedContentType = normalizeContentType(item.contentType());
-        validateScope(item.scope(), item.userRole(), item.category());
+        validateScope(item.scope(), userRole, item.category());
         validateContentType(item.category(), normalizedContentType);
         validateSize(item.category(), item.sizeBytes());
         validateDuration(item.category(), item.durationSecondsRequested());

--- a/backend/src/main/java/org/example/backend/media_asset/service/ObjectKeyGenerator.java
+++ b/backend/src/main/java/org/example/backend/media_asset/service/ObjectKeyGenerator.java
@@ -16,10 +16,10 @@ public class ObjectKeyGenerator {
     private static final int MAX_EXT_LENGTH = 10;
 
     // 요청 정보를 기반으로 규칙에 맞는 objectKey를 생성한다.
-    public String generate(PresignItemRequest item) {
+    public String generate(PresignItemRequest item, Long ownerUserId) {
         String ext = sanitizeExt(item.ext());
         String uuid = UUID.randomUUID().toString();
-        String prefix = resolvePrefix(item.category(), item.scope(), item.ownerUserId(),
+        String prefix = resolvePrefix(item.category(), item.scope(), ownerUserId,
                 item.postIdOrTemp(), item.replayIdOrTemp());
 
         return switch (item.category()) {


### PR DESCRIPTION
## 🎯 작업 영역
- [x] BE (Backend)
- [ ] FE (Frontend)


## 🛠 작업 사항
 Presign 요청 계약 변경
- PresignItemRequest에서 ownerUserId, userRole 제거
- 로그인 사용자 정보는 SecurityContext에서 서버가 주입

 Presign 권한/소유자 검증 강화
- 서버가 로그인 사용자 기준으로만 objectKey 생성 및 저장
- 클라 위변조 입력 차단

 ObjectKey 생성 로직 변경
- ObjectKeyGenerator.generate(item, ownerUserId) 형태로 변경
- ownerUserId는 서버에서만 전달

 Complete 처리 소유자 검증 추가
- mediaAsset.ownerUserId != 로그인 userId면 REJECTED + ACCESS_DENIED

 MediaPolicyValidator 시그니처 변경
- validatePresign(item, userRole)로 변경
- role은 서버에서 전달 


## 📸 스크린샷 (선택)

## 📚 관련 이슈
- Closes #
- Closes #


## ✅ 체크리스트
### 공통
- [x] 코드가 정상적으로 컴파일/빌드 되는가?
- [ ] 변경 사항에 대한 테스트를 진행했는가?
- [ ] 불필요한 로그(System.out.println 등)나 주석을 제거했는가?

### 특이 사항
- [ ] (백엔드) Swagger/API 문서를 현행화했는가?
- [ ] (공통) 새로운 환경 변수(application.yml, .env)가 필요한가?