### PR TITLE
Feat/concert

### DIFF
--- a/backend/src/main/java/org/example/backend/concert/controller/ConcertController.java
+++ b/backend/src/main/java/org/example/backend/concert/controller/ConcertController.java
@@ -1,0 +1,75 @@
+package org.example.backend.concert.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.backend.concert.dto.request.ConcertCreateRequest;
+import org.example.backend.concert.dto.request.ConcertUpdateRequest;
+import org.example.backend.concert.dto.response.ConcertResponse;
+import org.example.backend.concert.service.ConcertService;
+import org.example.backend.global.security.details.PrincipalDetails;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/concerts")
+public class ConcertController {
+
+    private final ConcertService concertService;
+
+    /**
+     * 공연 생성
+     */
+    @PostMapping
+    public ResponseEntity<ConcertResponse> createConcert(
+            @AuthenticationPrincipal PrincipalDetails principal,
+            @RequestBody @Valid ConcertCreateRequest request
+    ) {
+        ConcertResponse response = concertService.createConcert(principal.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 공연 조회 (단일)
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ConcertResponse> getConcert(@PathVariable Long id) {
+        ConcertResponse response = concertService.getConcert(id);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 공연 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<ConcertResponse>> getAllConcerts() {
+        List<ConcertResponse> response = concertService.getAllConcerts();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 공연 수정
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<ConcertResponse> updateConcert(
+            @AuthenticationPrincipal PrincipalDetails principal,
+            @PathVariable Long id,
+            @RequestBody @Valid ConcertUpdateRequest request
+    ) {
+        ConcertResponse response = concertService.updateConcert(id, principal.getUserId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 공연 삭제
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteConcert(@PathVariable Long id) {
+        concertService.deleteConcert(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/dto/request/ConcertCreateRequest.java
+++ b/backend/src/main/java/org/example/backend/concert/dto/request/ConcertCreateRequest.java
@@ -1,0 +1,31 @@
+package org.example.backend.concert.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConcertCreateRequest {
+    private String title;
+    private String description;
+    private Instant startDateTime;
+    private Instant endDateTime;
+    private String timezone;
+    private String venueName;
+    private Long locationId;
+    private String concertImageUrl;
+    private Integer presaleTicketCount;
+    private Integer saleTicketCount;
+    private Instant presaleStartDateTime;
+    private Instant presaleEndDateTime;
+    private Instant saleStartDateTime;
+    private Instant saleEndDateTime;
+    private List<Long> artistIds;
+}

--- a/backend/src/main/java/org/example/backend/concert/dto/request/ConcertCreateRequest.java
+++ b/backend/src/main/java/org/example/backend/concert/dto/request/ConcertCreateRequest.java
@@ -20,7 +20,7 @@ public class ConcertCreateRequest {
     private String timezone;
     private String venueName;
     private Long locationId;
-    private String concertImageUrl;
+    private Long posterMediaAssetId;
     private Integer presaleTicketCount;
     private Integer saleTicketCount;
     private Instant presaleStartDateTime;

--- a/backend/src/main/java/org/example/backend/concert/dto/request/ConcertUpdateRequest.java
+++ b/backend/src/main/java/org/example/backend/concert/dto/request/ConcertUpdateRequest.java
@@ -20,7 +20,7 @@ public class ConcertUpdateRequest {
     private String timezone;
     private String venueName;
     private Long locationId;
-    private String concertImageUrl;
+    private Long posterMediaAssetId;
     private Integer presaleTicketCount;
     private Integer saleTicketCount;
     private Instant presaleStartDateTime;

--- a/backend/src/main/java/org/example/backend/concert/dto/request/ConcertUpdateRequest.java
+++ b/backend/src/main/java/org/example/backend/concert/dto/request/ConcertUpdateRequest.java
@@ -1,0 +1,31 @@
+package org.example.backend.concert.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConcertUpdateRequest {
+    private String title;
+    private String description;
+    private Instant startDateTime;
+    private Instant endDateTime;
+    private String timezone;
+    private String venueName;
+    private Long locationId;
+    private String concertImageUrl;
+    private Integer presaleTicketCount;
+    private Integer saleTicketCount;
+    private Instant presaleStartDateTime;
+    private Instant presaleEndDateTime;
+    private Instant saleStartDateTime;
+    private Instant saleEndDateTime;
+    private List<Long> artistIds;
+}

--- a/backend/src/main/java/org/example/backend/concert/dto/response/ConcertMediaAssetResponse.java
+++ b/backend/src/main/java/org/example/backend/concert/dto/response/ConcertMediaAssetResponse.java
@@ -1,0 +1,27 @@
+package org.example.backend.concert.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.backend.concert.entity.ConcertMediaAssetType;
+import org.example.backend.media_asset.entity.MediaAsset;
+
+@Getter
+@Builder
+public class ConcertMediaAssetResponse {
+    private Long mediaAssetId;
+    private ConcertMediaAssetType type;
+    private String objectKey;
+    private String url;
+
+    public static ConcertMediaAssetResponse from(MediaAsset mediaAsset, ConcertMediaAssetType type, String cdnBaseUrl) {
+        String url = cdnBaseUrl != null && !cdnBaseUrl.isBlank()
+                ? (cdnBaseUrl.endsWith("/") ? cdnBaseUrl : cdnBaseUrl + "/") + mediaAsset.getObjectKey()
+                : null;
+        return ConcertMediaAssetResponse.builder()
+                .mediaAssetId(mediaAsset.getId())
+                .type(type)
+                .objectKey(mediaAsset.getObjectKey())
+                .url(url)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/dto/response/ConcertResponse.java
+++ b/backend/src/main/java/org/example/backend/concert/dto/response/ConcertResponse.java
@@ -24,7 +24,8 @@ public class ConcertResponse {
     private String timezone;
     private String venueName;
     private LocationResponse location;
-    private String concertImageUrl;
+    private String posterImageUrl;
+    private List<ConcertMediaAssetResponse> mediaAssets;
     private Integer presaleTicketCount;
     private Integer saleTicketCount;
     private Instant presaleStartDateTime;
@@ -35,7 +36,7 @@ public class ConcertResponse {
     private Instant updatedAt;
     private List<ArtistResponse> artists;
 
-    public static ConcertResponse from(Concert concert) {
+    public static ConcertResponse from(Concert concert, String posterImageUrl, List<ConcertMediaAssetResponse> mediaAssets) {
         return ConcertResponse.builder()
                 .id(concert.getId())
                 .title(concert.getTitle())
@@ -47,7 +48,8 @@ public class ConcertResponse {
                 .location(concert.getLocation() != null
                         ? LocationResponse.from(concert.getLocation())
                         : null)
-                .concertImageUrl(concert.getConcertImageUrl())
+                .posterImageUrl(posterImageUrl)
+                .mediaAssets(mediaAssets != null ? mediaAssets : Collections.emptyList())
                 .presaleTicketCount(concert.getPresaleTicketCount())
                 .saleTicketCount(concert.getSaleTicketCount())
                 .presaleStartDateTime(concert.getPresaleStartDateTime())

--- a/backend/src/main/java/org/example/backend/concert/dto/response/ConcertResponse.java
+++ b/backend/src/main/java/org/example/backend/concert/dto/response/ConcertResponse.java
@@ -1,0 +1,116 @@
+package org.example.backend.concert.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.backend.concert.entity.Concert;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConcertResponse {
+    private Long id;
+    private String title;
+    private String description;
+    private Instant startDateTime;
+    private Instant endDateTime;
+    private String timezone;
+    private String venueName;
+    private LocationResponse location;
+    private String concertImageUrl;
+    private Integer presaleTicketCount;
+    private Integer saleTicketCount;
+    private Instant presaleStartDateTime;
+    private Instant presaleEndDateTime;
+    private Instant saleStartDateTime;
+    private Instant saleEndDateTime;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private List<ArtistResponse> artists;
+
+    public static ConcertResponse from(Concert concert) {
+        return ConcertResponse.builder()
+                .id(concert.getId())
+                .title(concert.getTitle())
+                .description(concert.getDescription())
+                .startDateTime(concert.getStartDateTime())
+                .endDateTime(concert.getEndDateTime())
+                .timezone(concert.getTimezone())
+                .venueName(concert.getVenueName())
+                .location(concert.getLocation() != null
+                        ? LocationResponse.from(concert.getLocation())
+                        : null)
+                .concertImageUrl(concert.getConcertImageUrl())
+                .presaleTicketCount(concert.getPresaleTicketCount())
+                .saleTicketCount(concert.getSaleTicketCount())
+                .presaleStartDateTime(concert.getPresaleStartDateTime())
+                .presaleEndDateTime(concert.getPresaleEndDateTime())
+                .saleStartDateTime(concert.getSaleStartDateTime())
+                .saleEndDateTime(concert.getSaleEndDateTime())
+                .createdAt(concert.getCreatedAt())
+                .updatedAt(concert.getUpdatedAt())
+                .artists(concert.getArtists() == null
+                        ? Collections.emptyList()
+                        : concert.getArtists().stream()
+                                .map(ca -> ArtistResponse.from(ca.getArtist()))
+                                .collect(Collectors.toList()))
+                .build();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class LocationResponse {
+        private Long id;
+        private String country;
+        private String state;
+        private String city;
+        private String district;
+        private String street;
+        private String zipcode;
+        private Double latitude;
+        private Double longitude;
+        private String fullAddress;
+
+        public static LocationResponse from(org.example.backend.concert.entity.Location location) {
+            return LocationResponse.builder()
+                    .id(location.getId())
+                    .country(location.getCountry())
+                    .state(location.getState())
+                    .city(location.getCity())
+                    .district(location.getDistrict())
+                    .street(location.getStreet())
+                    .zipcode(location.getZipcode())
+                    .latitude(location.getLatitude())
+                    .longitude(location.getLongitude())
+                    .fullAddress(location.getFullAddress())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ArtistResponse {
+        private Long id;
+        private String nickname;
+        private String name;
+
+        public static ArtistResponse from(org.example.backend.user.entity.User artist) {
+            return ArtistResponse.builder()
+                    .id(artist.getId())
+                    .nickname(artist.getNickname())
+                    .name(artist.getName())
+                    .build();
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/entity/Concert.java
+++ b/backend/src/main/java/org/example/backend/concert/entity/Concert.java
@@ -1,0 +1,176 @@
+package org.example.backend.concert.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 공연 엔티티
+ */
+@Entity
+@Table(name = "concerts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Concert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private Instant startDateTime;
+
+    @Column(nullable = false)
+    private Instant endDateTime;
+
+    @Column(nullable = false, length = 50)
+    private String timezone;
+
+    @Column(nullable = false, length = 200)
+    private String venueName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private Location location;
+
+    @Column(length = 500)
+    private String concertImageUrl;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer presaleTicketCount = 0;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer saleTicketCount = 0;
+
+    @Column(nullable = false)
+    private Instant presaleStartDateTime;
+
+    @Column(nullable = false)
+    private Instant presaleEndDateTime;
+
+    @Column(nullable = false)
+    private Instant saleStartDateTime;
+
+    @Column(nullable = false)
+    private Instant saleEndDateTime;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    @OneToMany(mappedBy = "concert", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ConcertArtist> artists = new ArrayList<>();
+
+    /**
+     * 공연 정보 업데이트
+     */
+    public void updateInfo(
+            String title,
+            String description,
+            Instant startDateTime,
+            Instant endDateTime,
+            String timezone,
+            String venueName,
+            String concertImageUrl
+    ) {
+        this.title = title;
+        this.description = description;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+        this.timezone = timezone;
+        this.venueName = venueName;
+        this.concertImageUrl = concertImageUrl;
+    }
+
+    /**
+     * 티켓 판매 정보 업데이트
+     */
+    public void updateTicketInfo(
+            Integer presaleTicketCount,
+            Integer saleTicketCount,
+            Instant presaleStartDateTime,
+            Instant presaleEndDateTime,
+            Instant saleStartDateTime,
+            Instant saleEndDateTime
+    ) {
+        this.presaleTicketCount = presaleTicketCount;
+        this.saleTicketCount = saleTicketCount;
+        this.presaleStartDateTime = presaleStartDateTime;
+        this.presaleEndDateTime = presaleEndDateTime;
+        this.saleStartDateTime = saleStartDateTime;
+        this.saleEndDateTime = saleEndDateTime;
+    }
+
+    /**
+     * 위치 정보 업데이트
+     */
+    public void updateLocation(Location location) {
+        this.location = location;
+    }
+
+    /**
+     * 아티스트 추가
+     */
+    public void addArtist(ConcertArtist concertArtist) {
+        this.artists.add(concertArtist);
+        concertArtist.setConcert(this);
+    }
+
+    /**
+     * 아티스트 제거
+     */
+    public void removeArtist(ConcertArtist concertArtist) {
+        this.artists.remove(concertArtist);
+        concertArtist.setConcert(null);
+    }
+
+    /**
+     * 현재 시점에서 선예매 가능 여부 확인
+     */
+    public boolean isPresaleAvailable(Instant now) {
+        return now.isAfter(presaleStartDateTime) && now.isBefore(presaleEndDateTime);
+    }
+
+    /**
+     * 현재 시점에서 일반 예매 가능 여부 확인
+     */
+    public boolean isSaleAvailable(Instant now) {
+        return now.isAfter(saleStartDateTime) && now.isBefore(saleEndDateTime);
+    }
+
+    /**
+     * 공연 시작 여부 확인
+     */
+    public boolean isStarted(Instant now) {
+        return now.isAfter(startDateTime);
+    }
+
+    /**
+     * 공연 종료 여부 확인
+     */
+    public boolean isEnded(Instant now) {
+        return now.isAfter(endDateTime);
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/entity/Concert.java
+++ b/backend/src/main/java/org/example/backend/concert/entity/Concert.java
@@ -48,8 +48,9 @@ public class Concert {
     @JoinColumn(name = "location_id")
     private Location location;
 
-    @Column(length = 500)
-    private String concertImageUrl;
+    @OneToMany(mappedBy = "concert", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ConcertMediaAsset> mediaAssets = new ArrayList<>();
 
     @Column(nullable = false)
     @Builder.Default
@@ -92,8 +93,7 @@ public class Concert {
             Instant startDateTime,
             Instant endDateTime,
             String timezone,
-            String venueName,
-            String concertImageUrl
+            String venueName
     ) {
         this.title = title;
         this.description = description;
@@ -101,7 +101,16 @@ public class Concert {
         this.endDateTime = endDateTime;
         this.timezone = timezone;
         this.venueName = venueName;
-        this.concertImageUrl = concertImageUrl;
+    }
+
+    public void addMediaAsset(ConcertMediaAsset concertMediaAsset) {
+        this.mediaAssets.add(concertMediaAsset);
+        concertMediaAsset.setConcert(this);
+    }
+
+    public void removeMediaAsset(ConcertMediaAsset concertMediaAsset) {
+        this.mediaAssets.remove(concertMediaAsset);
+        concertMediaAsset.setConcert(null);
     }
 
     /**

--- a/backend/src/main/java/org/example/backend/concert/entity/ConcertArtist.java
+++ b/backend/src/main/java/org/example/backend/concert/entity/ConcertArtist.java
@@ -1,0 +1,50 @@
+package org.example.backend.concert.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.user.entity.User;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 공연-아티스트 M:N 관계 엔티티
+ */
+@Entity
+@Table(
+    name = "concert_artists",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"concert_id", "artist_id"})
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class ConcertArtist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id", nullable = false)
+    private Concert concert;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id", nullable = false)
+    private User artist;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    /**
+     * Concert 연관관계 설정 (양방향)
+     */
+    void setConcert(Concert concert) {
+        this.concert = concert;
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/entity/ConcertMediaAsset.java
+++ b/backend/src/main/java/org/example/backend/concert/entity/ConcertMediaAsset.java
@@ -1,0 +1,55 @@
+package org.example.backend.concert.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.backend.media_asset.entity.MediaAsset;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+    name = "concert_media_assets",
+    indexes = {
+        @Index(name = "idx_concert_media_assets_concert_id", columnList = "concert_id"),
+        @Index(name = "idx_concert_media_assets_media_asset_id", columnList = "media_asset_id")
+    }
+)
+public class ConcertMediaAsset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id", nullable = false)
+    private Concert concert;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private ConcertMediaAssetType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "media_asset_id", nullable = false)
+    private MediaAsset mediaAsset;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public ConcertMediaAsset(Concert concert, ConcertMediaAssetType type, MediaAsset mediaAsset) {
+        this.concert = concert;
+        this.type = type;
+        this.mediaAsset = mediaAsset;
+    }
+
+    void setConcert(Concert concert) {
+        this.concert = concert;
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/entity/ConcertMediaAssetType.java
+++ b/backend/src/main/java/org/example/backend/concert/entity/ConcertMediaAssetType.java
@@ -1,0 +1,5 @@
+package org.example.backend.concert.entity;
+
+public enum ConcertMediaAssetType {
+    POSTER
+}

--- a/backend/src/main/java/org/example/backend/concert/entity/Location.java
+++ b/backend/src/main/java/org/example/backend/concert/entity/Location.java
@@ -1,0 +1,63 @@
+package org.example.backend.concert.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * 공연 장소 위치 정보 엔티티
+ */
+@Entity
+@Table(name = "locations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String country;
+
+    @Column(nullable = false, length = 100)
+    private String state;
+
+    @Column(nullable = false, length = 100)
+    private String city;
+
+    @Column(length = 100)
+    private String district;
+
+    @Column(length = 200)
+    private String street;
+
+    @Column(length = 20)
+    private String zipcode;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    @Column(nullable = false, length = 500)
+    private String fullAddress;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    /**
+     * 전체 주소 업데이트
+     */
+    public void updateFullAddress(String fullAddress) {
+        this.fullAddress = fullAddress;
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/exception/ConcertErrorCode.java
+++ b/backend/src/main/java/org/example/backend/concert/exception/ConcertErrorCode.java
@@ -1,0 +1,54 @@
+package org.example.backend.concert.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ConcertErrorCode implements ErrorCode {
+
+    // ====== NOT FOUND ======
+    CONCERT_NOT_FOUND(HttpStatus.NOT_FOUND, "CONCERT_NOT_FOUND", "존재하지 않는 공연입니다."),
+    LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "LOCATION_NOT_FOUND", "존재하지 않는 위치입니다."),
+    CONCERT_ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "CONCERT_ARTIST_NOT_FOUND", "공연-아티스트 관계를 찾을 수 없습니다."),
+
+    // ====== 권한/소유 관련 ======
+    NOT_CONCERT_OWNER(HttpStatus.FORBIDDEN, "NOT_CONCERT_OWNER", "본인이 생성한 공연이 아닙니다."),
+    NOT_ARTIST_USER(HttpStatus.FORBIDDEN, "NOT_ARTIST_USER", "아티스트만 공연을 생성할 수 있습니다."),
+
+    // ====== 생성/수정 검증 ======
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "INVALID_DATE_RANGE", "공연 시작 시간은 종료 시간보다 이전이어야 합니다."),
+    INVALID_SALE_PERIOD(HttpStatus.BAD_REQUEST, "INVALID_SALE_PERIOD", "예매 기간이 공연 시간과 겹치거나 잘못되었습니다."),
+    INVALID_TICKET_COUNT(HttpStatus.BAD_REQUEST, "INVALID_TICKET_COUNT", "티켓 수량은 0 이상이어야 합니다."),
+    EMPTY_ARTIST_LIST(HttpStatus.BAD_REQUEST, "EMPTY_ARTIST_LIST", "공연에는 최소 1명의 아티스트가 필요합니다."),
+    DUPLICATE_ARTIST(HttpStatus.BAD_REQUEST, "DUPLICATE_ARTIST", "이미 추가된 아티스트입니다."),
+
+    // ====== 비즈니스 로직 ======
+    TICKET_SALE_NOT_STARTED(HttpStatus.BAD_REQUEST, "TICKET_SALE_NOT_STARTED", "아직 예매 시작 시간이 아닙니다."),
+    TICKET_SALE_ENDED(HttpStatus.BAD_REQUEST, "TICKET_SALE_ENDED", "예매 기간이 종료되었습니다."),
+    CONCERT_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "CONCERT_ALREADY_STARTED", "이미 시작된 공연입니다."),
+    CONCERT_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "CONCERT_ALREADY_ENDED", "이미 종료된 공연입니다."),
+    CANNOT_MODIFY_STARTED_CONCERT(HttpStatus.BAD_REQUEST, "CANNOT_MODIFY_STARTED_CONCERT", "시작된 공연은 수정할 수 없습니다."),
+    CANNOT_DELETE_STARTED_CONCERT(HttpStatus.BAD_REQUEST, "CANNOT_DELETE_STARTED_CONCERT", "시작된 공연은 삭제할 수 없습니다."),
+
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/exception/ConcertErrorCode.java
+++ b/backend/src/main/java/org/example/backend/concert/exception/ConcertErrorCode.java
@@ -11,6 +11,7 @@ public enum ConcertErrorCode implements ErrorCode {
     CONCERT_NOT_FOUND(HttpStatus.NOT_FOUND, "CONCERT_NOT_FOUND", "존재하지 않는 공연입니다."),
     LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "LOCATION_NOT_FOUND", "존재하지 않는 위치입니다."),
     CONCERT_ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "CONCERT_ARTIST_NOT_FOUND", "공연-아티스트 관계를 찾을 수 없습니다."),
+    MEDIA_ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "MEDIA_ASSET_NOT_FOUND", "존재하지 않는 미디어 에셋입니다."),
 
     // ====== 권한/소유 관련 ======
     NOT_CONCERT_OWNER(HttpStatus.FORBIDDEN, "NOT_CONCERT_OWNER", "본인이 생성한 공연이 아닙니다."),
@@ -22,6 +23,7 @@ public enum ConcertErrorCode implements ErrorCode {
     INVALID_TICKET_COUNT(HttpStatus.BAD_REQUEST, "INVALID_TICKET_COUNT", "티켓 수량은 0 이상이어야 합니다."),
     EMPTY_ARTIST_LIST(HttpStatus.BAD_REQUEST, "EMPTY_ARTIST_LIST", "공연에는 최소 1명의 아티스트가 필요합니다."),
     DUPLICATE_ARTIST(HttpStatus.BAD_REQUEST, "DUPLICATE_ARTIST", "이미 추가된 아티스트입니다."),
+    MEDIA_ASSET_NOT_READY(HttpStatus.BAD_REQUEST, "MEDIA_ASSET_NOT_READY", "미디어 에셋이 아직 업로드 완료되지 않았습니다."),
 
     // ====== 비즈니스 로직 ======
     TICKET_SALE_NOT_STARTED(HttpStatus.BAD_REQUEST, "TICKET_SALE_NOT_STARTED", "아직 예매 시작 시간이 아닙니다."),

--- a/backend/src/main/java/org/example/backend/concert/exception/ConcertException.java
+++ b/backend/src/main/java/org/example/backend/concert/exception/ConcertException.java
@@ -1,0 +1,14 @@
+package org.example.backend.concert.exception;
+
+import org.example.backend.global.exception.BusinessException;
+import org.example.backend.global.exception.ErrorCode;
+
+public class ConcertException extends BusinessException {
+    public ConcertException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ConcertException(ErrorCode errorCode, String overrideMessage) {
+        super(errorCode, overrideMessage);
+    }
+}

--- a/backend/src/main/java/org/example/backend/concert/repository/ConcertArtistRepository.java
+++ b/backend/src/main/java/org/example/backend/concert/repository/ConcertArtistRepository.java
@@ -1,0 +1,43 @@
+package org.example.backend.concert.repository;
+
+import org.example.backend.concert.entity.ConcertArtist;
+import org.example.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ConcertArtistRepository extends JpaRepository<ConcertArtist, Long> {
+
+    /**
+     * 공연 ID로 참여 아티스트 목록 조회
+     */
+    List<ConcertArtist> findByConcertId(Long concertId);
+
+    /**
+     * 아티스트 ID로 참여 공연 목록 조회
+     */
+    List<ConcertArtist> findByArtistId(Long artistId);
+
+    /**
+     * 공연과 아티스트로 관계 조회
+     */
+    Optional<ConcertArtist> findByConcertIdAndArtistId(Long concertId, Long artistId);
+
+    /**
+     * 공연에 참여하는 아티스트 존재 여부 확인
+     */
+    boolean existsByConcertIdAndArtistId(Long concertId, Long artistId);
+
+    /**
+     * 공연의 모든 아티스트 관계 삭제
+     */
+    void deleteByConcertId(Long concertId);
+
+    /**
+     * 아티스트의 모든 공연 관계 삭제
+     */
+    void deleteByArtistId(Long artistId);
+}

--- a/backend/src/main/java/org/example/backend/concert/repository/ConcertMediaAssetRepository.java
+++ b/backend/src/main/java/org/example/backend/concert/repository/ConcertMediaAssetRepository.java
@@ -1,0 +1,18 @@
+package org.example.backend.concert.repository;
+
+import org.example.backend.concert.entity.ConcertMediaAsset;
+import org.example.backend.concert.entity.ConcertMediaAssetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ConcertMediaAssetRepository extends JpaRepository<ConcertMediaAsset, Long> {
+
+    List<ConcertMediaAsset> findAllByConcertIdOrderById(Long concertId);
+
+    List<ConcertMediaAsset> findAllByConcertIdAndTypeOrderById(Long concertId, ConcertMediaAssetType type);
+
+    void deleteAllByConcertId(Long concertId);
+
+    void deleteAllByConcertIdAndType(Long concertId, ConcertMediaAssetType type);
+}

--- a/backend/src/main/java/org/example/backend/concert/repository/ConcertRepository.java
+++ b/backend/src/main/java/org/example/backend/concert/repository/ConcertRepository.java
@@ -1,0 +1,29 @@
+package org.example.backend.concert.repository;
+
+import org.example.backend.concert.entity.Concert;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface ConcertRepository extends JpaRepository<Concert, Long> {
+
+    /**
+     * 특정 시간 이후 시작하는 공연 목록 조회
+     */
+    List<Concert> findByStartDateTimeAfterOrderByStartDateTimeAsc(Instant startDateTime);
+
+    /**
+     * 특정 시간 이전에 종료된 공연 목록 조회
+     */
+    List<Concert> findByEndDateTimeBeforeOrderByEndDateTimeDesc(Instant endDateTime);
+
+    /**
+     * 현재 진행 중인 공연 목록 조회
+     */
+    List<Concert> findByStartDateTimeBeforeAndEndDateTimeAfterOrderByStartDateTimeAsc(
+            Instant now, Instant now2
+    );
+}

--- a/backend/src/main/java/org/example/backend/concert/repository/LocationRepository.java
+++ b/backend/src/main/java/org/example/backend/concert/repository/LocationRepository.java
@@ -1,0 +1,9 @@
+package org.example.backend.concert.repository;
+
+import org.example.backend.concert.entity.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LocationRepository extends JpaRepository<Location, Long> {
+}

--- a/backend/src/main/java/org/example/backend/concert/service/ConcertService.java
+++ b/backend/src/main/java/org/example/backend/concert/service/ConcertService.java
@@ -3,22 +3,32 @@ package org.example.backend.concert.service;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.concert.dto.request.ConcertCreateRequest;
 import org.example.backend.concert.dto.request.ConcertUpdateRequest;
+import org.example.backend.concert.dto.response.ConcertMediaAssetResponse;
 import org.example.backend.concert.dto.response.ConcertResponse;
 import org.example.backend.concert.entity.Concert;
 import org.example.backend.concert.entity.ConcertArtist;
+import org.example.backend.concert.entity.ConcertMediaAsset;
+import org.example.backend.concert.entity.ConcertMediaAssetType;
 import org.example.backend.concert.entity.Location;
 import org.example.backend.concert.exception.ConcertErrorCode;
 import org.example.backend.concert.exception.ConcertException;
 import org.example.backend.concert.repository.ConcertArtistRepository;
+import org.example.backend.concert.repository.ConcertMediaAssetRepository;
 import org.example.backend.concert.repository.ConcertRepository;
 import org.example.backend.concert.repository.LocationRepository;
+import org.example.backend.media_asset.config.AwsProperties;
+import org.example.backend.media_asset.entity.MediaAsset;
+import org.example.backend.media_asset.entity.MediaAssetStatus;
+import org.example.backend.media_asset.repository.MediaAssetRepository;
 import org.example.backend.user.entity.User;
 import org.example.backend.user.enums.UserRole;
 import org.example.backend.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,7 +40,10 @@ public class ConcertService {
     private final ConcertRepository concertRepository;
     private final LocationRepository locationRepository;
     private final ConcertArtistRepository concertArtistRepository;
+    private final ConcertMediaAssetRepository concertMediaAssetRepository;
+    private final MediaAssetRepository mediaAssetRepository;
     private final UserRepository userRepository;
+    private final AwsProperties awsProperties;
 
     /**
      * 공연 생성
@@ -63,7 +76,6 @@ public class ConcertService {
                 .timezone(request.getTimezone())
                 .venueName(request.getVenueName())
                 .location(location)
-                .concertImageUrl(request.getConcertImageUrl())
                 .presaleTicketCount(request.getPresaleTicketCount() != null ? request.getPresaleTicketCount() : 0)
                 .saleTicketCount(request.getSaleTicketCount() != null ? request.getSaleTicketCount() : 0)
                 .presaleStartDateTime(request.getPresaleStartDateTime())
@@ -74,6 +86,13 @@ public class ConcertService {
 
         Concert savedConcert = concertRepository.save(concert);
 
+        if (request.getPosterMediaAssetId() != null && request.getPosterMediaAssetId() > 0) {
+            MediaAsset posterAsset = validatePosterMediaAsset(request.getPosterMediaAssetId(), creatorId);
+            ConcertMediaAsset cma = new ConcertMediaAsset(savedConcert, ConcertMediaAssetType.POSTER, posterAsset);
+            savedConcert.addMediaAsset(cma);
+            concertMediaAssetRepository.save(cma);
+        }
+
         // 아티스트 추가 (artistIds가 없으면 생성자 본인을 추가)
         List<Long> artistIds = request.getArtistIds();
         if (artistIds == null || artistIds.isEmpty()) {
@@ -81,7 +100,7 @@ public class ConcertService {
         }
         addArtistsToConcert(savedConcert, artistIds);
 
-        return ConcertResponse.from(savedConcert);
+        return buildConcertResponse(savedConcert);
     }
 
     /**
@@ -91,7 +110,7 @@ public class ConcertService {
     public ConcertResponse getConcert(Long concertId) {
         Concert concert = concertRepository.findById(concertId)
                 .orElseThrow(() -> new ConcertException(ConcertErrorCode.CONCERT_NOT_FOUND));
-        return ConcertResponse.from(concert);
+        return buildConcertResponse(concert);
     }
 
     /**
@@ -100,7 +119,7 @@ public class ConcertService {
     @Transactional(readOnly = true)
     public List<ConcertResponse> getAllConcerts() {
         return concertRepository.findAll().stream()
-                .map(ConcertResponse::from)
+                .map(this::buildConcertResponse)
                 .collect(Collectors.toList());
     }
 
@@ -135,9 +154,16 @@ public class ConcertService {
                 request.getStartDateTime(),
                 request.getEndDateTime(),
                 request.getTimezone(),
-                request.getVenueName(),
-                request.getConcertImageUrl()
+                request.getVenueName()
         );
+
+        if (request.getPosterMediaAssetId() != null && request.getPosterMediaAssetId() > 0) {
+            concertMediaAssetRepository.deleteAllByConcertIdAndType(concert.getId(), ConcertMediaAssetType.POSTER);
+            MediaAsset posterAsset = validatePosterMediaAsset(request.getPosterMediaAssetId(), userId);
+            ConcertMediaAsset cma = new ConcertMediaAsset(concert, ConcertMediaAssetType.POSTER, posterAsset);
+            concert.addMediaAsset(cma);
+            concertMediaAssetRepository.save(cma);
+        }
 
         // 티켓 정보 업데이트
         concert.updateTicketInfo(
@@ -154,7 +180,53 @@ public class ConcertService {
             updateArtists(concert, request.getArtistIds());
         }
 
-        return ConcertResponse.from(concert);
+        return buildConcertResponse(concert);
+    }
+
+    private String getCdnBaseUrl() {
+        if (awsProperties.getCloudfront() == null) {
+            return null;
+        }
+        String domain = awsProperties.getCloudfront().getDomain();
+        if (domain == null || domain.isBlank()) {
+            return null;
+        }
+        return domain.startsWith("http") ? domain : "https://" + domain;
+    }
+
+    private MediaAsset validatePosterMediaAsset(Long mediaAssetId, Long ownerUserId) {
+        MediaAsset asset = mediaAssetRepository.findById(mediaAssetId)
+                .orElseThrow(() -> new ConcertException(ConcertErrorCode.MEDIA_ASSET_NOT_FOUND));
+        if (!asset.getOwnerUserId().equals(ownerUserId)) {
+            throw new ConcertException(ConcertErrorCode.NOT_ARTIST_USER);
+        }
+        if (asset.getStatus() != MediaAssetStatus.READY) {
+            throw new ConcertException(ConcertErrorCode.MEDIA_ASSET_NOT_READY);
+        }
+        return asset;
+    }
+
+    private ConcertResponse buildConcertResponse(Concert concert) {
+        List<ConcertMediaAsset> mediaAssetList = concertMediaAssetRepository.findAllByConcertIdOrderById(concert.getId());
+        String cdnBaseUrl = getCdnBaseUrl();
+        String posterImageUrl = null;
+        List<ConcertMediaAssetResponse> mediaAssetResponses = Collections.emptyList();
+        if (!CollectionUtils.isEmpty(mediaAssetList)) {
+            mediaAssetResponses = mediaAssetList.stream()
+                    .map(cma -> ConcertMediaAssetResponse.from(cma.getMediaAsset(), cma.getType(), cdnBaseUrl))
+                    .collect(Collectors.toList());
+            posterImageUrl = mediaAssetList.stream()
+                    .filter(cma -> cma.getType() == ConcertMediaAssetType.POSTER)
+                    .findFirst()
+                    .map(cma -> {
+                        String base = cdnBaseUrl != null && !cdnBaseUrl.isBlank()
+                                ? (cdnBaseUrl.endsWith("/") ? cdnBaseUrl : cdnBaseUrl + "/")
+                                : "";
+                        return base + cma.getMediaAsset().getObjectKey();
+                    })
+                    .orElse(null);
+        }
+        return ConcertResponse.from(concert, posterImageUrl, mediaAssetResponses);
     }
 
     /**

--- a/backend/src/main/java/org/example/backend/concert/service/ConcertService.java
+++ b/backend/src/main/java/org/example/backend/concert/service/ConcertService.java
@@ -1,0 +1,290 @@
+package org.example.backend.concert.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.concert.dto.request.ConcertCreateRequest;
+import org.example.backend.concert.dto.request.ConcertUpdateRequest;
+import org.example.backend.concert.dto.response.ConcertResponse;
+import org.example.backend.concert.entity.Concert;
+import org.example.backend.concert.entity.ConcertArtist;
+import org.example.backend.concert.entity.Location;
+import org.example.backend.concert.exception.ConcertErrorCode;
+import org.example.backend.concert.exception.ConcertException;
+import org.example.backend.concert.repository.ConcertArtistRepository;
+import org.example.backend.concert.repository.ConcertRepository;
+import org.example.backend.concert.repository.LocationRepository;
+import org.example.backend.user.entity.User;
+import org.example.backend.user.enums.UserRole;
+import org.example.backend.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ConcertService {
+
+    private final ConcertRepository concertRepository;
+    private final LocationRepository locationRepository;
+    private final ConcertArtistRepository concertArtistRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 공연 생성
+     */
+    public ConcertResponse createConcert(Long creatorId, ConcertCreateRequest request) {
+        // 아티스트 권한 확인
+        User creator = userRepository.findById(creatorId)
+                .orElseThrow(() -> new ConcertException(ConcertErrorCode.NOT_ARTIST_USER));
+        if (creator.getRole() != UserRole.ARTIST) {
+            throw new ConcertException(ConcertErrorCode.NOT_ARTIST_USER);
+        }
+
+        // 날짜 검증
+        validateDateRange(request.getStartDateTime(), request.getEndDateTime());
+        validateSalePeriod(request);
+
+        // 위치 조회
+        Location location = null;
+        if (request.getLocationId() != null) {
+            location = locationRepository.findById(request.getLocationId())
+                    .orElseThrow(() -> new ConcertException(ConcertErrorCode.LOCATION_NOT_FOUND));
+        }
+
+        // 공연 생성
+        Concert concert = Concert.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .startDateTime(request.getStartDateTime())
+                .endDateTime(request.getEndDateTime())
+                .timezone(request.getTimezone())
+                .venueName(request.getVenueName())
+                .location(location)
+                .concertImageUrl(request.getConcertImageUrl())
+                .presaleTicketCount(request.getPresaleTicketCount() != null ? request.getPresaleTicketCount() : 0)
+                .saleTicketCount(request.getSaleTicketCount() != null ? request.getSaleTicketCount() : 0)
+                .presaleStartDateTime(request.getPresaleStartDateTime())
+                .presaleEndDateTime(request.getPresaleEndDateTime())
+                .saleStartDateTime(request.getSaleStartDateTime())
+                .saleEndDateTime(request.getSaleEndDateTime())
+                .build();
+
+        Concert savedConcert = concertRepository.save(concert);
+
+        // 아티스트 추가 (artistIds가 없으면 생성자 본인을 추가)
+        List<Long> artistIds = request.getArtistIds();
+        if (artistIds == null || artistIds.isEmpty()) {
+            artistIds = List.of(creatorId);
+        }
+        addArtistsToConcert(savedConcert, artistIds);
+
+        return ConcertResponse.from(savedConcert);
+    }
+
+    /**
+     * 공연 조회 (단일)
+     */
+    @Transactional(readOnly = true)
+    public ConcertResponse getConcert(Long concertId) {
+        Concert concert = concertRepository.findById(concertId)
+                .orElseThrow(() -> new ConcertException(ConcertErrorCode.CONCERT_NOT_FOUND));
+        return ConcertResponse.from(concert);
+    }
+
+    /**
+     * 공연 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ConcertResponse> getAllConcerts() {
+        return concertRepository.findAll().stream()
+                .map(ConcertResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 공연 수정
+     */
+    public ConcertResponse updateConcert(Long concertId, Long userId, ConcertUpdateRequest request) {
+        Concert concert = concertRepository.findById(concertId)
+                .orElseThrow(() -> new ConcertException(ConcertErrorCode.CONCERT_NOT_FOUND));
+
+        // 공연 시작 여부 확인
+        Instant now = Instant.now();
+        if (concert.isStarted(now)) {
+            throw new ConcertException(ConcertErrorCode.CANNOT_MODIFY_STARTED_CONCERT);
+        }
+
+        // 날짜 검증
+        validateDateRange(request.getStartDateTime(), request.getEndDateTime());
+        validateSalePeriod(request);
+
+        // 위치 업데이트
+        if (request.getLocationId() != null) {
+            Location location = locationRepository.findById(request.getLocationId())
+                    .orElseThrow(() -> new ConcertException(ConcertErrorCode.LOCATION_NOT_FOUND));
+            concert.updateLocation(location);
+        }
+
+        // 공연 정보 업데이트
+        concert.updateInfo(
+                request.getTitle(),
+                request.getDescription(),
+                request.getStartDateTime(),
+                request.getEndDateTime(),
+                request.getTimezone(),
+                request.getVenueName(),
+                request.getConcertImageUrl()
+        );
+
+        // 티켓 정보 업데이트
+        concert.updateTicketInfo(
+                request.getPresaleTicketCount() != null ? request.getPresaleTicketCount() : concert.getPresaleTicketCount(),
+                request.getSaleTicketCount() != null ? request.getSaleTicketCount() : concert.getSaleTicketCount(),
+                request.getPresaleStartDateTime(),
+                request.getPresaleEndDateTime(),
+                request.getSaleStartDateTime(),
+                request.getSaleEndDateTime()
+        );
+
+        // 아티스트 업데이트
+        if (request.getArtistIds() != null) {
+            updateArtists(concert, request.getArtistIds());
+        }
+
+        return ConcertResponse.from(concert);
+    }
+
+    /**
+     * 공연 삭제
+     */
+    public void deleteConcert(Long concertId) {
+        Concert concert = concertRepository.findById(concertId)
+                .orElseThrow(() -> new ConcertException(ConcertErrorCode.CONCERT_NOT_FOUND));
+
+        // 공연 시작 여부 확인
+        Instant now = Instant.now();
+        if (concert.isStarted(now)) {
+            throw new ConcertException(ConcertErrorCode.CANNOT_DELETE_STARTED_CONCERT);
+        }
+
+        concertRepository.delete(concert);
+    }
+
+    /**
+     * 공연에 아티스트 추가
+     */
+    private void addArtistsToConcert(Concert concert, List<Long> artistIds) {
+        for (Long artistId : artistIds) {
+            User artist = userRepository.findById(artistId)
+                    .orElseThrow(() -> new ConcertException(ConcertErrorCode.NOT_ARTIST_USER));
+
+            // 중복 확인
+            if (concertArtistRepository.existsByConcertIdAndArtistId(concert.getId(), artistId)) {
+                continue;
+            }
+
+            ConcertArtist concertArtist = ConcertArtist.builder()
+                    .concert(concert)
+                    .artist(artist)
+                    .build();
+
+            concert.addArtist(concertArtist);
+            concertArtistRepository.save(concertArtist);
+        }
+    }
+
+    /**
+     * 공연의 아티스트 목록 업데이트
+     */
+    private void updateArtists(Concert concert, List<Long> artistIds) {
+        if (artistIds.isEmpty()) {
+            throw new ConcertException(ConcertErrorCode.EMPTY_ARTIST_LIST);
+        }
+
+        // 기존 아티스트 관계 삭제
+        List<ConcertArtist> existingArtists = concertArtistRepository.findByConcertId(concert.getId());
+        for (ConcertArtist existing : existingArtists) {
+            concert.removeArtist(existing);
+            concertArtistRepository.delete(existing);
+        }
+
+        // 새로운 아티스트 추가
+        addArtistsToConcert(concert, artistIds);
+    }
+
+    /**
+     * 날짜 범위 검증
+     */
+    private void validateDateRange(Instant startDateTime, Instant endDateTime) {
+        if (startDateTime.isAfter(endDateTime) || startDateTime.equals(endDateTime)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_DATE_RANGE);
+        }
+    }
+
+    /**
+     * 예매 기간 검증
+     */
+    private void validateSalePeriod(ConcertCreateRequest request) {
+        Instant startDateTime = request.getStartDateTime();
+        Instant endDateTime = request.getEndDateTime();
+        Instant presaleStart = request.getPresaleStartDateTime();
+        Instant presaleEnd = request.getPresaleEndDateTime();
+        Instant saleStart = request.getSaleStartDateTime();
+        Instant saleEnd = request.getSaleEndDateTime();
+
+        // 선예매 기간 검증
+        if (presaleStart.isAfter(presaleEnd) || presaleStart.equals(presaleEnd)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_SALE_PERIOD);
+        }
+
+        // 일반 예매 기간 검증
+        if (saleStart.isAfter(saleEnd) || saleStart.equals(saleEnd)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_SALE_PERIOD);
+        }
+
+        // 선예매 종료 후 일반 예매 시작 확인
+        if (presaleEnd.isAfter(saleStart)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_SALE_PERIOD);
+        }
+
+        // 예매 종료는 공연 시작 전이어야 함
+        if (saleEnd.isAfter(startDateTime)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_SALE_PERIOD);
+        }
+    }
+
+    /**
+     * 예매 기간 검증 (Update용)
+     */
+    private void validateSalePeriod(ConcertUpdateRequest request) {
+        Instant startDateTime = request.getStartDateTime();
+        Instant endDateTime = request.getEndDateTime();
+        Instant presaleStart = request.getPresaleStartDateTime();
+        Instant presaleEnd = request.getPresaleEndDateTime();
+        Instant saleStart = request.getSaleStartDateTime();
+        Instant saleEnd = request.getSaleEndDateTime();
+
+        // 선예매 기간 검증
+        if (presaleStart.isAfter(presaleEnd) || presaleStart.equals(presaleEnd)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_SALE_PERIOD);
+        }
+
+        // 일반 예매 기간 검증
+        if (saleStart.isAfter(saleEnd) || saleStart.equals(saleEnd)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_SALE_PERIOD);
+        }
+
+        // 선예매 종료 후 일반 예매 시작 확인
+        if (presaleEnd.isAfter(saleStart)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_SALE_PERIOD);
+        }
+
+        // 예매 종료는 공연 시작 전이어야 함
+        if (saleEnd.isAfter(startDateTime)) {
+            throw new ConcertException(ConcertErrorCode.INVALID_SALE_PERIOD);
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/global/config/SecurityConfig.java
@@ -110,6 +110,10 @@ public class SecurityConfig {
                 // 유저(팬), 아티스트, 그룹, 관리자
                 .requestMatchers("/api/user/**")
                     .hasAnyRole("USER", "ARTIST", "GROUP", "ADMIN")
+
+                // 공연 CRUD - 아티스트, 관리자
+                .requestMatchers("/api/concerts/**")
+                    .hasAnyRole("ARTIST", "ADMIN")
                 
                 // 그 외 모든 요청은 인증 필요
                 .anyRequest().authenticated()

--- a/backend/src/main/java/org/example/backend/user/dto/response/ArtistSearchResponse.java
+++ b/backend/src/main/java/org/example/backend/user/dto/response/ArtistSearchResponse.java
@@ -2,16 +2,18 @@ package org.example.backend.user.dto.response;
 
 import org.example.backend.user.entity.User;
 
-// 아티스트 검색 dto
+// 아티스트 검색 dto (nickname=예명, name=실명)
 public record ArtistSearchResponse(
         Long id,
         String nickname,
+        String name,
         String profileImageUrl
 ) {
     public static ArtistSearchResponse from(User user) {
         return new ArtistSearchResponse(
                 user.getId(),
                 user.getNickname(),
+                user.getName(),
                 user.getProfileImageUrl()
         );
     }

--- a/frontend/app/artist-console/concerts/[id]/edit/page.js
+++ b/frontend/app/artist-console/concerts/[id]/edit/page.js
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, useRef } from "react";
+import { useRouter, useParams, useSearchParams } from "next/navigation";
 import axios from "axios";
 import Surface from "@/components/ui/Surface";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
 
 const CONCERTS_API = "http://localhost:8080/api/concerts";
+const USER_PROFILE_API = "http://localhost:8080/api/user/profile";
 
 function getAuthHeaders() {
   const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
@@ -34,19 +35,34 @@ function parseJwt(token) {
   }
 }
 
-export default function NewConcertPage() {
+function toLocalDateTime(instantStr) {
+  if (!instantStr) return "";
+  const d = new Date(instantStr);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString().slice(0, 16);
+}
+
+export default function EditConcertPage() {
   const router = useRouter();
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const id = params?.id;
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+  const [fetchError, setFetchError] = useState("");
+  const [submitError, setSubmitError] = useState("");
   const [userId, setUserId] = useState(null);
 
+  // JWT에는 userId가 없고 subject가 이메일이므로, 프로필 API로 현재 사용자 ID 조회
   useEffect(() => {
-    const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
-    if (token) {
-      const payload = parseJwt(token);
-      if (payload?.userId != null) setUserId(payload.userId);
-      else if (payload?.sub != null && /^\d+$/.test(String(payload.sub))) setUserId(Number(payload.sub));
-    }
+    if (typeof window === "undefined") return;
+    const token = localStorage.getItem("accessToken");
+    if (!token) return;
+    axios
+      .get(USER_PROFILE_API, { headers: getAuthHeaders() })
+      .then((res) => {
+        if (res?.data?.id != null) setUserId(Number(res.data.id));
+      })
+      .catch(() => {});
   }, []);
 
   const [title, setTitle] = useState("");
@@ -58,55 +74,153 @@ export default function NewConcertPage() {
   const [locationId, setLocationId] = useState("");
   const [posterMediaAssetId, setPosterMediaAssetId] = useState("");
   const [selectedArtists, setSelectedArtists] = useState([]);
-
-  // select-artists에서 돌아온 뒤: 저장해 둔 폼 초안 복원 + 추가 아티스트 병합
-  useEffect(() => {
-    try {
-      const draftRaw = sessionStorage.getItem("concertNewDraft");
-      if (draftRaw) {
-        sessionStorage.removeItem("concertNewDraft");
-        const draft = JSON.parse(draftRaw);
-        if (draft && typeof draft === "object") {
-          if (draft.title != null) setTitle(String(draft.title));
-          if (draft.description != null) setDescription(String(draft.description));
-          if (draft.startDateTime != null) setStartDateTime(String(draft.startDateTime));
-          if (draft.endDateTime != null) setEndDateTime(String(draft.endDateTime));
-          if (draft.timezone != null) setTimezone(String(draft.timezone));
-          if (draft.venueName != null) setVenueName(String(draft.venueName));
-          if (draft.locationId != null) setLocationId(String(draft.locationId));
-          if (draft.posterMediaAssetId != null) setPosterMediaAssetId(String(draft.posterMediaAssetId));
-          if (draft.presaleTicketCount != null) setPresaleTicketCount(String(draft.presaleTicketCount));
-          if (draft.saleTicketCount != null) setSaleTicketCount(String(draft.saleTicketCount));
-          if (draft.presaleStartDateTime != null) setPresaleStartDateTime(String(draft.presaleStartDateTime));
-          if (draft.presaleEndDateTime != null) setPresaleEndDateTime(String(draft.presaleEndDateTime));
-          if (draft.saleStartDateTime != null) setSaleStartDateTime(String(draft.saleStartDateTime));
-          if (draft.saleEndDateTime != null) setSaleEndDateTime(String(draft.saleEndDateTime));
-          if (Array.isArray(draft.selectedArtists) && draft.selectedArtists.length > 0) {
-            setSelectedArtists(draft.selectedArtists.map((a) => ({ id: a.id, nickname: a.nickname ?? "", profileImageUrl: a.profileImageUrl ?? null })));
-          }
-        }
-      }
-      const raw = sessionStorage.getItem("concertAddArtists");
-      if (raw) {
-        sessionStorage.removeItem("concertAddArtists");
-        const added = JSON.parse(raw);
-        if (Array.isArray(added) && added.length > 0) {
-          setSelectedArtists((prev) => {
-            const byId = new Map(prev.map((a) => [a.id, a]));
-            added.forEach((a) => byId.set(a.id, { id: a.id, nickname: a.nickname, profileImageUrl: a.profileImageUrl }));
-            return Array.from(byId.values());
-          });
-        }
-      }
-    } catch (_) {}
-  }, []);
-
   const [presaleTicketCount, setPresaleTicketCount] = useState("");
   const [saleTicketCount, setSaleTicketCount] = useState("");
   const [presaleStartDateTime, setPresaleStartDateTime] = useState("");
   const [presaleEndDateTime, setPresaleEndDateTime] = useState("");
   const [saleStartDateTime, setSaleStartDateTime] = useState("");
   const [saleEndDateTime, setSaleEndDateTime] = useState("");
+  const [initialized, setInitialized] = useState(false);
+  // select-artists에서 돌아올 때 추가한 아티스트 (마운트 직후 한 번만 읽어서 fetch 완료 시 병합에 사용)
+  const pendingAddedArtistsRef = useRef(null);
+  // searchParams effect에서 이미 병합했으면 fetch 완료 시 selectedArtists 덮어쓰지 않음
+  const mergedInSearchParamsRef = useRef(false);
+  // Strict Mode 등으로 fetch가 두 번 완료될 때, 이미 저장 목록(concertEditSelectedArtists) 적용했으면 API로 덮어쓰지 않음
+  const appliedSavedArtistsRef = useRef(false);
+
+  // 마운트 시 sessionStorage에 추가 아티스트가 있으면 ref에 보관 (fetch 완료 후 병합)
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem("concertAddArtists");
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        pendingAddedArtistsRef.current = parsed;
+      }
+    } catch (_) {}
+  }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchConcert = async () => {
+      try {
+        setFetchError("");
+        const res = await axios.get(`${CONCERTS_API}/${id}`, { headers: getAuthHeaders() });
+        const c = res.data;
+        setTitle(c.title ?? "");
+        setDescription(c.description ?? "");
+        setStartDateTime(toLocalDateTime(c.startDateTime));
+        setEndDateTime(toLocalDateTime(c.endDateTime));
+        setTimezone(c.timezone ?? "Asia/Seoul");
+        setVenueName(c.venueName ?? "");
+        setLocationId(c.location?.id != null ? String(c.location.id) : "");
+        setPosterMediaAssetId("");
+        let baseArtists = Array.isArray(c.artists)
+          ? c.artists.map((a) => ({ id: a.id, nickname: a.nickname ?? "", profileImageUrl: null }))
+          : [];
+        let usedSavedArtists = false;
+        try {
+          const savedRaw = sessionStorage.getItem("concertEditSelectedArtists");
+          if (savedRaw) {
+            const saved = JSON.parse(savedRaw);
+            if (Array.isArray(saved) && saved.length >= 0) {
+              baseArtists = saved.map((a) => ({ id: a.id, nickname: a.nickname ?? "", profileImageUrl: a.profileImageUrl ?? null }));
+              sessionStorage.removeItem("concertEditSelectedArtists");
+              usedSavedArtists = true;
+            }
+          }
+        } catch (_) {}
+        let artistsToSet = baseArtists;
+        let added = pendingAddedArtistsRef.current;
+        if (!added || !Array.isArray(added) || added.length === 0) {
+          try {
+            const raw = sessionStorage.getItem("concertAddArtists");
+            if (raw) {
+              const parsed = JSON.parse(raw);
+              if (Array.isArray(parsed) && parsed.length > 0) added = parsed;
+            }
+          } catch (_) {}
+        }
+        if (Array.isArray(added) && added.length > 0) {
+          const byId = new Map(baseArtists.map((a) => [a.id, a]));
+          added.forEach((a) => byId.set(a.id, { id: a.id, nickname: a.nickname ?? "", profileImageUrl: a.profileImageUrl ?? null }));
+          artistsToSet = Array.from(byId.values());
+          pendingAddedArtistsRef.current = null;
+        }
+        if (!mergedInSearchParamsRef.current && !appliedSavedArtistsRef.current) {
+          setSelectedArtists(artistsToSet);
+        }
+        if (usedSavedArtists) appliedSavedArtistsRef.current = true;
+        else appliedSavedArtistsRef.current = false;
+        mergedInSearchParamsRef.current = false;
+        setPresaleTicketCount(c.presaleTicketCount != null ? String(c.presaleTicketCount) : "");
+        setSaleTicketCount(c.saleTicketCount != null ? String(c.saleTicketCount) : "");
+        setPresaleStartDateTime(toLocalDateTime(c.presaleStartDateTime));
+        setPresaleEndDateTime(toLocalDateTime(c.presaleEndDateTime));
+        setSaleStartDateTime(toLocalDateTime(c.saleStartDateTime));
+        setSaleEndDateTime(toLocalDateTime(c.saleEndDateTime));
+      } catch (err) {
+        setFetchError(err.response?.data?.message || err.response?.status === 404 ? "공연을 찾을 수 없습니다." : "불러오기에 실패했습니다.");
+      } finally {
+        setInitialized(true);
+      }
+    };
+    fetchConcert();
+  }, [id]);
+
+  // select-artists에서 돌아왔을 때: concertEditSelectedArtists가 있으면 그걸 기준으로, 없으면 현재 state 기준으로 추가 아티스트만 병합
+  useEffect(() => {
+    if (!id || searchParams?.get("from") !== "select-artists") return;
+    try {
+      let base = [];
+      const savedRaw = sessionStorage.getItem("concertEditSelectedArtists");
+      if (savedRaw) {
+        const saved = JSON.parse(savedRaw);
+        if (Array.isArray(saved)) {
+          base = saved.map((a) => ({ id: a.id, nickname: a.nickname ?? "", profileImageUrl: a.profileImageUrl ?? null }));
+          // 제거는 fetch에서만 함 (fetch가 나중에 완료돼도 덮어쓰지 않도록 mergedInSearchParamsRef 사용)
+        }
+      }
+      const raw = sessionStorage.getItem("concertAddArtists");
+      const added = raw ? JSON.parse(raw) : null;
+      if (Array.isArray(added) && added.length > 0) {
+        mergedInSearchParamsRef.current = true;
+        const byId = new Map(base.map((a) => [a.id, a]));
+        added.forEach((a) => byId.set(a.id, { id: a.id, nickname: a.nickname ?? "", profileImageUrl: a.profileImageUrl ?? null }));
+        setSelectedArtists(Array.from(byId.values()));
+      } else if (base.length > 0) {
+        mergedInSearchParamsRef.current = true;
+        setSelectedArtists(base);
+      }
+    } catch (_) {}
+  }, [id, searchParams]);
+
+  // initialized 후 한 번 더 sessionStorage 병합 (fetch가 먼저 끝나 ref가 비었을 때 대비)
+  useEffect(() => {
+    if (!id || !initialized) return;
+    try {
+      const raw = sessionStorage.getItem("concertAddArtists");
+      if (!raw) return;
+      const added = JSON.parse(raw);
+      if (!Array.isArray(added) || added.length === 0) return;
+      setSelectedArtists((prev) => {
+        const byId = new Map(prev.map((a) => [a.id, a]));
+        added.forEach((a) => byId.set(a.id, { id: a.id, nickname: a.nickname ?? "", profileImageUrl: a.profileImageUrl ?? null }));
+        return Array.from(byId.values());
+      });
+    } catch (_) {}
+  }, [id, initialized]);
+
+  // 생성 시처럼 수정 시에도 참여 아티스트에 본인(userId)이 없으면 목록에 유지
+  useEffect(() => {
+    if (userId == null || !initialized) return;
+    const uid = Number(userId);
+    if (!Number.isInteger(uid) || uid <= 0) return;
+    setSelectedArtists((prev) => {
+      if (prev.some((a) => Number(a.id) === uid)) return prev;
+      return [{ id: uid, nickname: "나", profileImageUrl: null }, ...prev];
+    });
+  }, [userId, initialized]);
 
   const toInstant = (localDateTimeStr) => {
     if (!localDateTimeStr || !localDateTimeStr.trim()) return null;
@@ -121,35 +235,46 @@ export default function NewConcertPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError("");
+    setSubmitError("");
     if (!title.trim()) {
-      setError("공연 제목을 입력해주세요.");
+      setSubmitError("공연 제목을 입력해주세요.");
       return;
     }
     if (!startDateTime) {
-      setError("공연 시작 시간을 입력해주세요.");
+      setSubmitError("공연 시작 시간을 입력해주세요.");
       return;
     }
     if (!endDateTime) {
-      setError("공연 종료 시간을 입력해주세요.");
+      setSubmitError("공연 종료 시간을 입력해주세요.");
       return;
     }
     if (!venueName.trim()) {
-      setError("장소명을 입력해주세요.");
+      setSubmitError("장소명을 입력해주세요.");
       return;
     }
 
     setLoading(true);
     try {
       const posterId = toNum(posterMediaAssetId);
-      const rawIds = [
-        ...(userId != null && Number.isInteger(Number(userId)) ? [Number(userId)] : []),
-        ...selectedArtists.map((a) => Number(a.id)),
-      ].filter((id) => id > 0 && Number.isInteger(id));
-      const artistIds = rawIds.length > 0 ? [...new Set(rawIds)] : undefined;
+      // 본인 ID: state → 없으면 프로필 API로 조회 (JWT에는 userId가 없음)
+      let uid = userId != null && Number.isInteger(Number(userId)) ? Number(userId) : null;
+      if (uid == null && typeof window !== "undefined") {
+        try {
+          const res = await axios.get(USER_PROFILE_API, { headers: getAuthHeaders() });
+          if (res?.data?.id != null) uid = Number(res.data.id);
+        } catch (_) {}
+      }
+      const idsFromSelection = selectedArtists
+        .map((a) => Number(a.id))
+        .filter((id) => id > 0 && Number.isInteger(id));
+      // 참여 아티스트 목록에 자신이 없으면 무조건 맨 앞에 넣어서 수정 완료되게 함
+      const hasSelf = uid != null && idsFromSelection.some((id) => id === uid);
+      const rawIds = hasSelf ? idsFromSelection : uid != null ? [uid, ...idsFromSelection] : idsFromSelection;
+      // 본인만 있어도 최소 1명이므로 항상 배열로 전송 (undefined면 백엔드가 아티스트를 갱신하지 않음)
+      const artistIds = rawIds.length > 0 ? [...new Set(rawIds)] : uid != null ? [uid] : undefined;
 
-      await axios.post(
-        CONCERTS_API,
+      await axios.put(
+        `${CONCERTS_API}/${id}`,
         {
           title: title.trim(),
           description: description.trim() || null,
@@ -170,15 +295,37 @@ export default function NewConcertPage() {
         { headers: getAuthHeaders() }
       );
       try {
-        sessionStorage.removeItem("concertNewDraft");
+        sessionStorage.removeItem("concertAddArtists");
+        sessionStorage.removeItem("concertEditSelectedArtists");
       } catch (_) {}
       router.push("/artist-console/concerts");
     } catch (err) {
-      setError(err.response?.data?.message || err.response?.data?.errorCode || err.message || "저장에 실패했습니다.");
+      setSubmitError(err.response?.data?.message || err.response?.data?.errorCode || err.message || "수정에 실패했습니다.");
     } finally {
       setLoading(false);
     }
   };
+
+  if (!initialized) {
+    return (
+      <div className="p-8 lg:p-12 max-w-3xl mx-auto">
+        <div className="text-white/55 text-center py-12">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="p-8 lg:p-12 max-w-3xl mx-auto space-y-6">
+        <Button variant="ghost" href="/artist-console/concerts" className="size-10 rounded-full">
+          <span className="material-symbols-outlined">arrow_back</span>
+        </Button>
+        <div className="p-4 rounded-2xl bg-red-500/10 border border-red-500/20 text-red-400/90 text-sm">
+          {fetchError}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-8 lg:p-12 max-w-3xl mx-auto space-y-8">
@@ -187,14 +334,14 @@ export default function NewConcertPage() {
           <span className="material-symbols-outlined">arrow_back</span>
         </Button>
         <div>
-          <SectionTitle className="text-2xl font-bold">새 공연 등록</SectionTitle>
-          <p className="text-white/55 text-sm font-medium mt-1">공연 정보와 예매 일정을 입력하세요.</p>
+          <SectionTitle className="text-2xl font-bold">공연 수정</SectionTitle>
+          <p className="text-white/55 text-sm font-medium mt-1">공연 정보와 예매 일정을 수정하세요.</p>
         </div>
       </header>
 
-      {error && (
+      {submitError && (
         <div className="p-4 rounded-2xl bg-red-500/10 border border-red-500/20 text-red-400/90 text-sm">
-          {error}
+          {submitError}
         </div>
       )}
 
@@ -295,7 +442,7 @@ export default function NewConcertPage() {
               type="number"
               value={posterMediaAssetId}
               onChange={(e) => setPosterMediaAssetId(e.target.value)}
-              placeholder="없으면 비워두세요"
+              placeholder="변경 시에만 입력, 없으면 비워두세요"
               min="0"
               className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-violet-500/20"
             />
@@ -328,26 +475,10 @@ export default function NewConcertPage() {
               className="text-violet-400 hover:text-violet-300"
               onClick={() => {
                 try {
-                  sessionStorage.setItem("concertSelectArtistsReturn", "/artist-console/concerts/new");
+                  sessionStorage.setItem("concertSelectArtistsReturn", `/artist-console/concerts/${id}/edit`);
                   sessionStorage.setItem(
-                    "concertNewDraft",
-                    JSON.stringify({
-                      title,
-                      description,
-                      startDateTime,
-                      endDateTime,
-                      timezone,
-                      venueName,
-                      locationId,
-                      posterMediaAssetId,
-                      presaleTicketCount,
-                      saleTicketCount,
-                      presaleStartDateTime,
-                      presaleEndDateTime,
-                      saleStartDateTime,
-                      saleEndDateTime,
-                      selectedArtists: selectedArtists.map((a) => ({ id: a.id, nickname: a.nickname, profileImageUrl: a.profileImageUrl })),
-                    })
+                    "concertEditSelectedArtists",
+                    JSON.stringify(selectedArtists.map((a) => ({ id: a.id, nickname: a.nickname, profileImageUrl: a.profileImageUrl })))
                   );
                 } catch (_) {}
                 router.push("/artist-console/concerts/new/select-artists");
@@ -432,7 +563,7 @@ export default function NewConcertPage() {
             취소
           </Button>
           <Button type="submit" variant="primary" className="px-8 py-3" disabled={loading}>
-            {loading ? "저장 중…" : "공연 등록"}
+            {loading ? "저장 중…" : "수정 완료"}
           </Button>
         </div>
       </form>

--- a/frontend/app/artist-console/concerts/new/page.js
+++ b/frontend/app/artist-console/concerts/new/page.js
@@ -1,0 +1,380 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+import { MOCK_ARTISTS } from "@/lib/mockData";
+import Surface from "@/components/ui/Surface";
+import SectionTitle from "@/components/ui/SectionTitle";
+import Button from "@/components/ui/Button";
+
+const CONCERTS_API = "http://localhost:8080/api/concerts";
+
+function getAuthHeaders() {
+  const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+  return {
+    "Content-Type": "application/json",
+    ...(token && { Authorization: token }),
+  };
+}
+
+function parseJwt(token) {
+  try {
+    const base64Url = token.split(".")[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+        .join("")
+    );
+    return JSON.parse(jsonPayload);
+  } catch {
+    return null;
+  }
+}
+
+export default function NewConcertPage() {
+  const router = useRouter();
+  const artist = MOCK_ARTISTS[0];
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [userId, setUserId] = useState(null);
+
+  // JWT에서 사용자 ID 추출
+  useEffect(() => {
+    const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+    if (token) {
+      const payload = parseJwt(token);
+      if (payload?.userId || payload?.sub) {
+        setUserId(payload.userId || payload.sub);
+      }
+    }
+  }, []);
+
+  // 기본 정보
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [startDateTime, setStartDateTime] = useState("");
+  const [endDateTime, setEndDateTime] = useState("");
+  const [timezone, setTimezone] = useState("Asia/Seoul");
+  const [venueName, setVenueName] = useState("");
+  const [locationId, setLocationId] = useState("");
+  const [concertImageUrl, setConcertImageUrl] = useState("");
+
+  // 티켓 정보
+  const [presaleTicketCount, setPresaleTicketCount] = useState("");
+  const [saleTicketCount, setSaleTicketCount] = useState("");
+  const [presaleStartDateTime, setPresaleStartDateTime] = useState("");
+  const [presaleEndDateTime, setPresaleEndDateTime] = useState("");
+  const [saleStartDateTime, setSaleStartDateTime] = useState("");
+  const [saleEndDateTime, setSaleEndDateTime] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+
+    // 필수 필드 검증
+    if (!title.trim()) {
+      setError("공연 제목을 입력해주세요.");
+      return;
+    }
+    if (!startDateTime) {
+      setError("공연 시작 시간을 입력해주세요.");
+      return;
+    }
+    if (!endDateTime) {
+      setError("공연 종료 시간을 입력해주세요.");
+      return;
+    }
+    if (!venueName.trim()) {
+      setError("장소명을 입력해주세요.");
+      return;
+    }
+    if (!presaleStartDateTime) {
+      setError("선예매 시작 시간을 입력해주세요.");
+      return;
+    }
+    if (!presaleEndDateTime) {
+      setError("선예매 종료 시간을 입력해주세요.");
+      return;
+    }
+    if (!saleStartDateTime) {
+      setError("일반 예매 시작 시간을 입력해주세요.");
+      return;
+    }
+    if (!saleEndDateTime) {
+      setError("일반 예매 종료 시간을 입력해주세요.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      // 빈 문자열을 null로 변환하는 헬퍼
+      const toNullIfEmpty = (value) => {
+        if (value === null || value === undefined) return null;
+        const trimmed = String(value).trim();
+        return trimmed === "" ? null : trimmed;
+      };
+
+      const requestData = {
+        title: title.trim(),
+        description: toNullIfEmpty(description),
+        startDateTime: new Date(startDateTime).toISOString(),
+        endDateTime: new Date(endDateTime).toISOString(),
+        timezone: timezone || "Asia/Seoul",
+        venueName: venueName.trim(),
+        locationId: locationId && locationId.trim() ? parseInt(locationId.trim()) : null,
+        concertImageUrl: toNullIfEmpty(concertImageUrl),
+        presaleTicketCount: presaleTicketCount ? parseInt(presaleTicketCount) : 0,
+        saleTicketCount: saleTicketCount ? parseInt(saleTicketCount) : 0,
+        presaleStartDateTime: new Date(presaleStartDateTime).toISOString(),
+        presaleEndDateTime: new Date(presaleEndDateTime).toISOString(),
+        saleStartDateTime: new Date(saleStartDateTime).toISOString(),
+        saleEndDateTime: new Date(saleEndDateTime).toISOString(),
+        // artistIds는 백엔드에서 Principal의 userId를 자동으로 사용
+      };
+
+      console.log("Request Data:", JSON.stringify(requestData, null, 2)); // 디버깅용
+
+      await axios.post(CONCERTS_API, requestData, { headers: getAuthHeaders() });
+      router.push("/artist-console/concerts");
+    } catch (err) {
+      console.error("Error:", err.response?.data); // 디버깅용
+      setError(
+        err.response?.data?.message ||
+        err.response?.data?.error ||
+        "공연 등록에 실패했습니다. 모든 필수 항목을 확인해주세요."
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-8 lg:p-12 max-w-4xl mx-auto space-y-8">
+      <header className="flex items-center gap-4">
+        <Button variant="ghost" href="/artist-console/concerts" className="size-10 rounded-full">
+          <span className="material-symbols-outlined">arrow_back</span>
+        </Button>
+        <div>
+          <SectionTitle className="text-2xl font-bold">새 공연 등록</SectionTitle>
+          <p className="text-white/55 text-sm font-medium mt-1">공연 정보와 예매 일정을 입력하세요.</p>
+        </div>
+      </header>
+
+      {error && (
+        <div className="p-4 rounded-2xl bg-red-500/10 border border-red-500/20 text-red-400/90 text-sm">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* 기본 정보 */}
+        <Surface variant="primary" className="p-8 space-y-6">
+          <h3 className="text-lg font-bold text-white mb-4">기본 정보</h3>
+
+          <label className="block">
+            <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+              공연 제목 <span className="text-red-400">*</span>
+            </span>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="공연 제목을 입력하세요"
+              className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-violet-500/20"
+              required
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">공연 설명</span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="공연에 대한 설명을 입력하세요"
+              className="w-full min-h-[120px] bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-violet-500/20 resize-y"
+            />
+          </label>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+                공연 시작 시간 <span className="text-red-400">*</span>
+              </span>
+              <input
+                type="datetime-local"
+                value={startDateTime}
+                onChange={(e) => setStartDateTime(e.target.value)}
+                className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white outline-none focus:ring-2 focus:ring-violet-500/20"
+                required
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+                공연 종료 시간 <span className="text-red-400">*</span>
+              </span>
+              <input
+                type="datetime-local"
+                value={endDateTime}
+                onChange={(e) => setEndDateTime(e.target.value)}
+                className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white outline-none focus:ring-2 focus:ring-violet-500/20"
+                required
+              />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+                타임존 <span className="text-red-400">*</span>
+              </span>
+              <select
+                value={timezone}
+                onChange={(e) => setTimezone(e.target.value)}
+                className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white outline-none focus:ring-2 focus:ring-violet-500/20"
+                required
+              >
+                <option value="Asia/Seoul">Asia/Seoul (한국)</option>
+                <option value="America/New_York">America/New_York (미국 동부)</option>
+                <option value="America/Los_Angeles">America/Los_Angeles (미국 서부)</option>
+                <option value="Europe/London">Europe/London (영국)</option>
+                <option value="Asia/Tokyo">Asia/Tokyo (일본)</option>
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+                장소명 <span className="text-red-400">*</span>
+              </span>
+              <input
+                type="text"
+                value={venueName}
+                onChange={(e) => setVenueName(e.target.value)}
+                placeholder="예: 올림픽공원 올림픽홀"
+                className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-violet-500/20"
+                required
+              />
+            </label>
+          </div>
+
+          <label className="block">
+            <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">공연 이미지 URL</span>
+            <input
+              type="url"
+              value={concertImageUrl}
+              onChange={(e) => setConcertImageUrl(e.target.value)}
+              placeholder="https://example.com/poster.jpg"
+              className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-violet-500/20"
+            />
+          </label>
+        </Surface>
+
+        {/* 티켓 정보 */}
+        <Surface variant="primary" className="p-8 space-y-6">
+          <h3 className="text-lg font-bold text-white mb-4">티켓 정보</h3>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">선예매 티켓 수량</span>
+              <input
+                type="number"
+                value={presaleTicketCount}
+                onChange={(e) => setPresaleTicketCount(e.target.value)}
+                placeholder="0"
+                min="0"
+                className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-violet-500/20"
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">일반 예매 티켓 수량</span>
+              <input
+                type="number"
+                value={saleTicketCount}
+                onChange={(e) => setSaleTicketCount(e.target.value)}
+                placeholder="0"
+                min="0"
+                className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-violet-500/20"
+              />
+            </label>
+          </div>
+
+          <div className="space-y-4">
+            <h4 className="text-sm font-bold text-white/80">선예매 기간</h4>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <label className="block">
+                <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+                  선예매 시작 시간 <span className="text-red-400">*</span>
+                </span>
+                <input
+                  type="datetime-local"
+                  value={presaleStartDateTime}
+                  onChange={(e) => setPresaleStartDateTime(e.target.value)}
+                  className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white outline-none focus:ring-2 focus:ring-violet-500/20"
+                  required
+                />
+              </label>
+
+              <label className="block">
+                <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+                  선예매 종료 시간 <span className="text-red-400">*</span>
+                </span>
+                <input
+                  type="datetime-local"
+                  value={presaleEndDateTime}
+                  onChange={(e) => setPresaleEndDateTime(e.target.value)}
+                  className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white outline-none focus:ring-2 focus:ring-violet-500/20"
+                  required
+                />
+              </label>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <h4 className="text-sm font-bold text-white/80">일반 예매 기간</h4>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <label className="block">
+                <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+                  일반 예매 시작 시간 <span className="text-red-400">*</span>
+                </span>
+                <input
+                  type="datetime-local"
+                  value={saleStartDateTime}
+                  onChange={(e) => setSaleStartDateTime(e.target.value)}
+                  className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white outline-none focus:ring-2 focus:ring-violet-500/20"
+                  required
+                />
+              </label>
+
+              <label className="block">
+                <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
+                  일반 예매 종료 시간 <span className="text-red-400">*</span>
+                </span>
+                <input
+                  type="datetime-local"
+                  value={saleEndDateTime}
+                  onChange={(e) => setSaleEndDateTime(e.target.value)}
+                  className="w-full bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white outline-none focus:ring-2 focus:ring-violet-500/20"
+                  required
+                />
+              </label>
+            </div>
+          </div>
+        </Surface>
+
+        <div className="flex gap-3 justify-end">
+          <Button variant="ghost" href="/artist-console/concerts" disabled={loading}>
+            취소
+          </Button>
+          <Button type="submit" variant="primary" className="px-8 py-3" disabled={loading}>
+            {loading ? "등록 중..." : "공연 등록하기"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/artist-console/concerts/new/select-artists/page.js
+++ b/frontend/app/artist-console/concerts/new/select-artists/page.js
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+import Surface from "@/components/ui/Surface";
+import SectionTitle from "@/components/ui/SectionTitle";
+import Button from "@/components/ui/Button";
+
+const ARTISTS_API = "http://localhost:8080/api/user/artists";
+
+function getAuthHeaders() {
+  const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+  const bearer = token && (token.startsWith("Bearer ") ? token : `Bearer ${token.trim()}`);
+  return {
+    "Content-Type": "application/json",
+    ...(bearer && { Authorization: bearer }),
+  };
+}
+
+export default function SelectArtistsPage() {
+  const router = useRouter();
+  const [keyword, setKeyword] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [artists, setArtists] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [addedArtists, setAddedArtists] = useState([]);
+
+  useEffect(() => {
+    const fetchArtists = async () => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (searchKeyword.trim()) params.set("nickname", searchKeyword.trim());
+        params.set("page", page);
+        params.set("size", 20);
+        const res = await axios.get(`${ARTISTS_API}?${params.toString()}`, {
+          headers: getAuthHeaders(),
+        });
+        setArtists(res.data?.content ?? []);
+        setTotalPages(res.data?.totalPages ?? 0);
+      } catch (err) {
+        setArtists([]);
+        setTotalPages(0);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchArtists();
+  }, [searchKeyword, page]);
+
+  const handleSearch = (e) => {
+    e?.preventDefault();
+    setSearchKeyword(keyword);
+    setPage(0);
+  };
+
+  const addArtist = (artist) => {
+    if (addedArtists.some((a) => a.id === artist.id)) return;
+    setAddedArtists((prev) => [...prev, { id: artist.id, nickname: artist.nickname, profileImageUrl: artist.profileImageUrl }]);
+  };
+
+  const removeAdded = (id) => {
+    setAddedArtists((prev) => prev.filter((a) => a.id !== id));
+  };
+
+  const getReturnPath = () => {
+    try {
+      const path = sessionStorage.getItem("concertSelectArtistsReturn");
+      if (path && typeof path === "string" && path.startsWith("/artist-console/concerts")) return path;
+    } catch (_) {}
+    return "/artist-console/concerts/new";
+  };
+
+  const finishSelection = () => {
+    if (addedArtists.length > 0) {
+      try {
+        sessionStorage.setItem("concertAddArtists", JSON.stringify(addedArtists));
+      } catch (_) {}
+    }
+    let returnPath = getReturnPath();
+    try {
+      sessionStorage.removeItem("concertSelectArtistsReturn");
+    } catch (_) {}
+    if (returnPath.includes("/edit") && addedArtists.length > 0) {
+      returnPath = returnPath.replace(/\?.*$/, "") + "?from=select-artists";
+    }
+    router.push(returnPath);
+  };
+
+  const handleBack = () => {
+    const returnPath = getReturnPath();
+    try {
+      sessionStorage.removeItem("concertSelectArtistsReturn");
+    } catch (_) {}
+    router.push(returnPath);
+  };
+
+  return (
+    <div className="p-8 lg:p-12 max-w-4xl mx-auto space-y-8">
+      <header className="flex items-center gap-4">
+        <Button
+          variant="ghost"
+          onClick={handleBack}
+          className="size-10 rounded-full"
+        >
+          <span className="material-symbols-outlined">arrow_back</span>
+        </Button>
+        <div>
+          <SectionTitle className="text-2xl font-bold">아티스트 검색</SectionTitle>
+          <p className="text-white/55 text-sm font-medium mt-1">공연에 참여할 아티스트를 검색해 추가하세요.</p>
+        </div>
+      </header>
+
+      <Surface variant="primary" className="p-6 space-y-4">
+        <form onSubmit={handleSearch} className="flex gap-2">
+          <input
+            type="text"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            placeholder="닉네임 또는 그룹명으로 검색"
+            className="flex-1 bg-[#16102a] border border-white/[0.08] rounded-xl px-4 py-3 text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-violet-500/20"
+          />
+          <Button type="submit" variant="primary" className="px-6">
+            검색
+          </Button>
+        </form>
+
+        {addedArtists.length > 0 && (
+          <div className="pt-2 border-t border-white/[0.08]">
+            <p className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2">
+              이번에 추가할 아티스트 ({addedArtists.length}명)
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {addedArtists.map((a) => (
+                <span
+                  key={a.id}
+                  className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-violet-500/20 text-white text-sm"
+                >
+                  {a.nickname}
+                  <button
+                    type="button"
+                    onClick={() => removeAdded(a.id)}
+                    className="hover:text-red-400"
+                    aria-label="제거"
+                  >
+                    <span className="material-symbols-outlined text-lg">close</span>
+                  </button>
+                </span>
+              ))}
+            </div>
+            <Button
+              type="button"
+              variant="primary"
+              className="mt-3"
+              onClick={finishSelection}
+            >
+              선택 완료하고 공연 등록으로 돌아가기
+            </Button>
+          </div>
+        )}
+      </Surface>
+
+      <Surface variant="primary" className="p-6">
+        <h3 className="text-lg font-bold text-white mb-4">검색 결과</h3>
+        {loading ? (
+          <p className="text-white/55">검색 중...</p>
+        ) : artists.length === 0 ? (
+          <p className="text-white/55">
+            {searchKeyword ? "검색 결과가 없습니다." : "검색어를 입력하고 검색해 보세요."}
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {artists.map((artist) => {
+              const added = addedArtists.some((a) => a.id === artist.id);
+              return (
+                <li
+                  key={artist.id}
+                  className="flex items-center justify-between gap-4 py-3 px-4 rounded-xl bg-[#16102a] border border-white/[0.06]"
+                >
+                  <div className="flex items-center gap-3">
+                    {artist.profileImageUrl ? (
+                      <img
+                        src={artist.profileImageUrl}
+                        alt=""
+                        className="w-10 h-10 rounded-full object-cover"
+                      />
+                    ) : (
+                      <div className="w-10 h-10 rounded-full bg-white/10 flex items-center justify-center">
+                        <span className="material-symbols-outlined text-white/50">person</span>
+                      </div>
+                    )}
+                    <span className="font-medium text-white">{artist.nickname}</span>
+                  </div>
+                  <Button
+                    type="button"
+                    variant={added ? "ghost" : "primary"}
+                    className="shrink-0"
+                    onClick={() => addArtist(artist)}
+                    disabled={added}
+                  >
+                    {added ? "추가됨" : "추가"}
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {totalPages > 1 && (
+          <div className="flex justify-center gap-2 mt-4">
+            <Button
+              variant="ghost"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+            >
+              이전
+            </Button>
+            <span className="text-white/55 text-sm py-2">
+              {page + 1} / {totalPages}
+            </span>
+            <Button
+              variant="ghost"
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+            >
+              다음
+            </Button>
+          </div>
+        )}
+      </Surface>
+    </div>
+  );
+}

--- a/frontend/app/artist-console/concerts/page.js
+++ b/frontend/app/artist-console/concerts/page.js
@@ -11,9 +11,10 @@ const CONCERTS_API = "http://localhost:8080/api/concerts";
 
 function getAuthHeaders() {
   const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+  const bearer = token && (token.startsWith("Bearer ") ? token : `Bearer ${token.trim()}`);
   return {
     "Content-Type": "application/json",
-    ...(token && { Authorization: token }),
+    ...(bearer && { Authorization: bearer }),
   };
 }
 
@@ -102,9 +103,9 @@ export default function ArtistConcertsPage() {
               <div className="flex items-start justify-between gap-6">
                 <div className="flex-1">
                   <div className="flex items-center gap-4 mb-4">
-                    {concert.concertImageUrl && (
-                      <img
-                        src={concert.concertImageUrl}
+{(concert.posterImageUrl || concert.concertImageUrl) && (
+                        <img
+                          src={concert.posterImageUrl || concert.concertImageUrl}
                         className="size-24 rounded-xl object-cover border border-white/[0.08]"
                         alt=""
                       />

--- a/frontend/app/artist-console/concerts/page.js
+++ b/frontend/app/artist-console/concerts/page.js
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import axios from "axios";
+import Surface from "@/components/ui/Surface";
+import SectionTitle from "@/components/ui/SectionTitle";
+import Button from "@/components/ui/Button";
+
+const CONCERTS_API = "http://localhost:8080/api/concerts";
+
+function getAuthHeaders() {
+  const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+  return {
+    "Content-Type": "application/json",
+    ...(token && { Authorization: token }),
+  };
+}
+
+export default function ArtistConcertsPage() {
+  const [concerts, setConcerts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetchConcerts();
+  }, []);
+
+  const fetchConcerts = async () => {
+    try {
+      setLoading(true);
+      setError("");
+      const res = await axios.get(CONCERTS_API, { headers: getAuthHeaders() });
+      setConcerts(res.data || []);
+    } catch (err) {
+      setError(err.response?.data?.message || "공연 목록을 불러오는데 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm("정말 이 공연을 삭제하시겠습니까?")) return;
+    try {
+      await axios.delete(`${CONCERTS_API}/${id}`, { headers: getAuthHeaders() });
+      await fetchConcerts();
+    } catch (err) {
+      alert(err.response?.data?.message || "삭제에 실패했습니다.");
+    }
+  };
+
+  const formatDateTime = (instantStr) => {
+    if (!instantStr) return "-";
+    const date = new Date(instantStr);
+    return date.toLocaleString("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="p-8 lg:p-12 max-w-5xl mx-auto">
+        <div className="text-white/55 text-center py-12">로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 lg:p-12 max-w-5xl mx-auto space-y-10">
+      <header className="flex items-center justify-between">
+        <div>
+          <SectionTitle className="text-2xl font-bold">공연 관리</SectionTitle>
+          <p className="text-sm text-white/55 font-medium mt-1">공연 정보를 관리하고 예매 일정을 설정합니다.</p>
+        </div>
+        <Button variant="primary" href="/artist-console/concerts/new" className="text-xs uppercase tracking-widest">
+          <span className="material-symbols-outlined text-sm mr-1.5">add</span>
+          새 공연 등록
+        </Button>
+      </header>
+
+      {error && (
+        <div className="p-4 rounded-2xl bg-red-500/10 border border-red-500/20 text-red-400/90 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {concerts.length === 0 ? (
+          <Surface variant="primary" className="p-12 text-center">
+            <p className="text-white/55 font-medium mb-4">등록된 공연이 없습니다.</p>
+            <Button variant="primary" href="/artist-console/concerts/new" className="text-xs uppercase tracking-widest">
+              첫 공연 등록하기
+            </Button>
+          </Surface>
+        ) : (
+          concerts.map((concert) => (
+            <Surface key={concert.id} variant="primary" className="p-8 hover:shadow-[0_8px_24px_rgba(0,0,0,0.5)] transition-shadow">
+              <div className="flex items-start justify-between gap-6">
+                <div className="flex-1">
+                  <div className="flex items-center gap-4 mb-4">
+                    {concert.concertImageUrl && (
+                      <img
+                        src={concert.concertImageUrl}
+                        className="size-24 rounded-xl object-cover border border-white/[0.08]"
+                        alt=""
+                      />
+                    )}
+                    <div className="flex-1">
+                      <h3 className="text-xl font-bold text-white mb-2">{concert.title}</h3>
+                      <p className="text-sm text-white/70 mb-3 line-clamp-2">{concert.description}</p>
+                      <div className="flex flex-wrap gap-4 text-xs text-white/55">
+                        <span>
+                          <span className="font-bold">장소:</span> {concert.venueName}
+                        </span>
+                        <span>
+                          <span className="font-bold">시작:</span> {formatDateTime(concert.startDateTime)}
+                        </span>
+                        <span>
+                          <span className="font-bold">종료:</span> {formatDateTime(concert.endDateTime)}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-xs text-white/55 mt-4">
+                    <span>
+                      선예매: {concert.presaleTicketCount}장 ({formatDateTime(concert.presaleStartDateTime)} ~ {formatDateTime(concert.presaleEndDateTime)})
+                    </span>
+                    <span>
+                      일반 예매: {concert.saleTicketCount}장 ({formatDateTime(concert.saleStartDateTime)} ~ {formatDateTime(concert.saleEndDateTime)})
+                    </span>
+                  </div>
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <Button variant="ghost" href={`/artist-console/concerts/${concert.id}/edit`} className="px-4 py-2 text-[10px] uppercase tracking-widest">
+                    수정
+                  </Button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(concert.id)}
+                    className="px-4 py-2 bg-red-500/15 text-red-400/90 rounded-xl text-[10px] font-black uppercase tracking-widest hover:bg-red-500/25 transition-colors"
+                  >
+                    삭제
+                  </button>
+                </div>
+              </div>
+            </Surface>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/artist-console/page.js
+++ b/frontend/app/artist-console/page.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { MOCK_ARTISTS, MOCK_POSTS, MOCK_LIVES } from "@/lib/mockData";
 import Surface from "@/components/ui/Surface";
 import SectionTitle from "@/components/ui/SectionTitle";
@@ -49,20 +50,35 @@ export default function ArtistConsolePage() {
           { id: "POSTS", label: "My Posts" },
           { id: "FAN_POSTS", label: "Fan Posts" },
           { id: "LIVE", label: "Live History" },
-        ].map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => setActiveTab(tab.id)}
-            className={`px-8 py-3 rounded-xl text-xs font-black uppercase tracking-widest transition-all ${
-              activeTab === tab.id
-                ? "bg-[#201a33] text-violet-300 border border-white/[0.08]"
-                : "text-white/55 hover:text-white/80"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+          { id: "CONCERTS", label: "Concerts", href: "/artist-console/concerts" },
+        ].map((tab) =>
+          tab.href ? (
+            <Link
+              key={tab.id}
+              href={tab.href}
+              className={`px-8 py-3 rounded-xl text-xs font-black uppercase tracking-widest transition-all ${
+                activeTab === tab.id
+                  ? "bg-[#201a33] text-violet-300 border border-white/[0.08]"
+                  : "text-white/55 hover:text-white/80"
+              }`}
+            >
+              {tab.label}
+            </Link>
+          ) : (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-8 py-3 rounded-xl text-xs font-black uppercase tracking-widest transition-all ${
+                activeTab === tab.id
+                  ? "bg-[#201a33] text-violet-300 border border-white/[0.08]"
+                  : "text-white/55 hover:text-white/80"
+              }`}
+            >
+              {tab.label}
+            </button>
+          )
+        )}
       </div>
 
       <div className="space-y-6">

--- a/frontend/app/artist-console/page.js
+++ b/frontend/app/artist-console/page.js
@@ -37,12 +37,6 @@ export default function ArtistConsolePage() {
             <span className="inline-flex items-center leading-none text-xs font-black text-violet-300">{me.postCount}</span>
           </div>
         </div>
-        <div className="flex flex-wrap justify-center items-center gap-3">
-          <Button variant="primary" href="/artist-console/group-dm" className="text-xs uppercase tracking-widest">
-            <span className="material-symbols-outlined text-sm fill-icon mr-1.5">send</span>
-            DM
-          </Button>
-        </div>
       </Surface>
 
       <div className="flex items-center gap-2 p-1 bg-white/[0.04] rounded-2xl w-fit border border-white/[0.06]">

--- a/frontend/app/providers/NotificationProvider.js
+++ b/frontend/app/providers/NotificationProvider.js
@@ -1,12 +1,14 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useRef, useState, useCallback } from "react";
+import { usePathname } from "next/navigation";
 import axios from "axios";
 
 const NotificationContext = createContext(null);
 const API_BASE = "http://localhost:8080/api/notifications";
 
 export function NotificationProvider({ children }) {
+    const pathname = usePathname();
     const [notifications, setNotifications] = useState([]);
     const [unreadCount, setUnreadCount] = useState(0);
 
@@ -123,7 +125,8 @@ export function NotificationProvider({ children }) {
             abortRef.current?.abort();
             clearTimeout(reconnectRef.current);
         };
-    }, [fetchUnreadCount]);
+        // pathname 포함: 알림 페이지 접근 시 effect 재실행 → SSE 재연결 (새로고침 없이 실시간 수신)
+    }, [fetchUnreadCount, pathname]);
 
     /* ===== 읽음 처리 ===== */
     const markAsRead = useCallback(async (id) => {

--- a/frontend/components/navbar/ArtistNavBar.jsx
+++ b/frontend/components/navbar/ArtistNavBar.jsx
@@ -33,33 +33,9 @@ export default function ArtistNavBar() {
           }`}>
           Artist Console
         </Link>
-        <Link
-          href="/milestone"
-          className={`inline-flex items-center leading-none h-8 text-[15px] font-bold transition-colors ${
-            pathname === "/milestone" || pathname?.startsWith("/milestone/")
-              ? "text-violet-300"
-              : "text-white/80 hover:text-violet-300"
-          }`}>
-          등급 관리
-        </Link>
-        <Link
-          href="/dm/artist"
-          className={`inline-flex items-center leading-none h-8 text-[15px] font-bold transition-colors ${
-            pathname === "/dm/artist" || pathname?.startsWith("/dm/artist")
-              ? "text-violet-300"
-              : "text-white/80 hover:text-violet-300"
-          }`}>
-          DM
-        </Link>
       </nav>
 
       <div className="flex items-center gap-6 shrink-0">
-        <Link
-          href="/dm/artist"
-          className="p-2 text-white/80 hover:bg-white/10 rounded-full transition-colors"
-          aria-label="DM">
-          <span className="material-symbols-outlined">mail</span>
-        </Link>
         <Link
           href="/notifications"
           className="p-2 text-white/80 hover:bg-white/10 rounded-full transition-colors relative"

--- a/frontend/components/navbar/FanNavBar.jsx
+++ b/frontend/components/navbar/FanNavBar.jsx
@@ -2,47 +2,10 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState, useEffect, useRef } from "react";
-import axios from "axios";
 
-function getAuthHeaders() {
-  if (typeof window === "undefined") return {};
-  const token = localStorage.getItem("accessToken");
-  const pure = token?.replace(/^Bearer\s+/i, "").trim();
-  return pure ? { Authorization: `Bearer ${pure}` } : {};
-}
-
-/** 팬(일반 사용자) 영역 NavBar. DM 목록은 DB에서 불러와 드롭다운으로 표시. */
+/** 팬(일반 사용자) 영역 NavBar. */
 export default function FanNavBar() {
   const pathname = usePathname();
-  const [dmRooms, setDmRooms] = useState([]);
-  const [dmOpen, setDmOpen] = useState(false);
-  const dmNavRef = useRef(null);
-  const dmIconRef = useRef(null);
-
-  useEffect(() => {
-    const headers = getAuthHeaders();
-    if (!headers.Authorization) return;
-    axios
-      .get("http://localhost:8080/api/chat/DM/rooms", { headers })
-      .then((res) => setDmRooms(res.data || []))
-      .catch(() => setDmRooms([]));
-  }, [pathname]);
-
-  useEffect(() => {
-    const handleClickOutside = (e) => {
-      const inNav = dmNavRef.current?.contains(e.target);
-      const inIcon = dmIconRef.current?.contains(e.target);
-      if (!inNav && !inIcon) setDmOpen(false);
-    };
-    document.addEventListener("click", handleClickOutside);
-    return () => document.removeEventListener("click", handleClickOutside);
-  }, []);
-
-  const getRoomAvatar = (room) =>
-    `https://picsum.photos/seed/${room?.roomId || room?.hostName || "dm"}/100/100`;
-
-  const isDmPage = pathname === "/dm/fan" || pathname?.startsWith("/dm/fan");
 
   return (
     <header className="fixed top-0 left-0 right-0 h-16 bg-[#0b0814]/95 backdrop-blur-md border-b border-white/[0.06] z-50 px-6 lg:px-12 flex items-center justify-between">
@@ -91,51 +54,6 @@ export default function FanNavBar() {
       </nav>
 
       <div className="flex items-center gap-6 shrink-0">
-        <div className="relative" ref={dmIconRef}>
-          <button
-            type="button"
-            onClick={(e) => { e.stopPropagation(); setDmOpen((o) => !o); }}
-            className="p-2 text-white/80 hover:bg-white/10 rounded-full transition-colors"
-            aria-label="DM">
-            <span className="material-symbols-outlined">mail</span>
-          </button>
-          {dmOpen && (
-            <div className="absolute top-full right-0 mt-2 w-64 rounded-2xl border border-white/[0.06] bg-[#201a33] shadow-xl py-2 z-50 max-h-80 overflow-y-auto custom-scrollbar">
-              {dmRooms.length === 0 ? (
-                <Link
-                  href="/dm/fan"
-                  onClick={() => setDmOpen(false)}
-                  className="block px-4 py-3 text-sm text-white/55 hover:bg-white/[0.06]">
-                  DM 방이 없습니다
-                </Link>
-              ) : (
-                dmRooms.map((room) => (
-                  <Link
-                    key={room.roomId}
-                    href={`/dm/fan?roomId=${room.roomId}`}
-                    onClick={() => setDmOpen(false)}
-                    className="flex items-center gap-3 px-4 py-3 hover:bg-white/[0.06] transition-colors">
-                    <img
-                      src={getRoomAvatar(room)}
-                      alt=""
-                      className="size-9 rounded-full border border-white/[0.08]"
-                    />
-                    <div className="flex-1 min-w-0">
-                      <span className="text-sm font-bold text-white truncate block">
-                        {room.hostName}
-                      </span>
-                      {room.groupName && (
-                        <span className="text-[10px] text-white/55 font-medium uppercase tracking-wider truncate block">
-                          {room.groupName}
-                        </span>
-                      )}
-                    </div>
-                  </Link>
-                ))
-              )}
-            </div>
-          )}
-        </div>
         <Link
           href="/notifications"
           className="p-2 text-white/80 hover:bg-white/10 rounded-full transition-colors relative"


### PR DESCRIPTION
## 🎯 작업 영역
- [x] BE (Backend)
- [x] FE (Frontend)


## 🛠 작업 사항

1. 공연 (Concerts)
공연 crud 작성 및 기타 서비스 추가 
공연 엔티티 부분에 미디어 에셋 추가
참여 아티스트 유지: 수정 페이지에서 아티스트 제거(X) 후 검색 페이지 다녀와도 제거한 상태가 유지되도록 sessionStorage·searchParams·ref 처리 보완.
본인 자동 포함: 수정 시 참여 아티스트에 본인(userId)이 없으면 목록·제출 payload에 자동 포함 (프로필 API로 userId 조회, JWT 미사용).
저장 시 본인 보장: 수정 저장 시 참여 아티스트에 본인이 없으면 artistIds에 본인을 넣어 전송하고, 빈 배열이 되지 않도록 처리.

2. 공연·백엔드/인증
인가: /api/concerts/**는 ARTIST, ADMIN만 접근 가능하도록 SecurityConfig에 추가.
아티스트 검색 API: 아티스트 검색 응답 DTO에 실명 필드 name 추가 (ArtistSearchResponse).

3. 프론트 – 네비/UI 정리
아티스트 네비: 아티스트 상단 네비에서 “등급 관리”, “DM” 메뉴 및 DM 아이콘 제거.
팬 네비: 팬 상단 네비에서 DM 드롭다운(메일 아이콘·방 목록) 제거.
아티스트 콘솔 메인: /artist-console 상단 카드의 “DM” 버튼 제거.


## 📸 스크린샷 (선택)

## 📚 관련 이슈
- Closes #
- Closes #


## ✅ 체크리스트
### 공통
- [x] 코드가 정상적으로 컴파일/빌드 되는가?
- [x] 변경 사항에 대한 테스트를 진행했는가?
- [x] 불필요한 로그(System.out.println 등)나 주석을 제거했는가?

### 특이 사항
- [ ] (백엔드) Swagger/API 문서를 현행화했는가?
- [ ] (공통) 새로운 환경 변수(application.yml, .env)가 필요한가?