### PR TITLE
fix: ffprobeVideoMetadataExtractor 빈이 두 군데에서 등록되고 있음. 수정 완료

### DIFF
--- a/backend/src/main/java/org/example/backend/media_asset/metadata/FfprobeVideoMetadataExtractor.java
+++ b/backend/src/main/java/org/example/backend/media_asset/metadata/FfprobeVideoMetadataExtractor.java
@@ -2,7 +2,6 @@ package org.example.backend.media_asset.metadata;
 
 import org.example.backend.media_asset.config.AwsProperties;
 import org.example.backend.media_asset.config.MediaProperties;
-import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -17,7 +16,6 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-@Component
 public class FfprobeVideoMetadataExtractor implements VideoMetadataExtractor {
 
     private final S3Client s3Client;


### PR DESCRIPTION
## 🎯 작업 영역
- [x] BE (Backend)
- [ ] FE (Frontend)


## 🛠 작업 사항
- 
- 


## 📸 스크린샷 (선택)

## 📚 관련 이슈
- Closes #
- Closes #


## ✅ 체크리스트
### 공통
- [ ] 코드가 정상적으로 컴파일/빌드 되는가?
- [ ] 변경 사항에 대한 테스트를 진행했는가?
- [ ] 불필요한 로그(System.out.println 등)나 주석을 제거했는가?

### 특이 사항
- [ ] (백엔드) Swagger/API 문서를 현행화했는가?
- [ ] (공통) 새로운 환경 변수(application.yml, .env)가 필요한가?