### PR TITLE
chore: deploy.yml 수정...

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,21 +29,19 @@ jobs:
           role-to-assume: ${{ env.ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Resolve ECR URI
+      - name: Resolve ECR URI + Tag
         id: ecr
         shell: bash
         run: |
           set -euo pipefail
           ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
-          echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
-          echo "ecr_uri=${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}" >> "$GITHUB_OUTPUT"
-          echo "IMAGE_TAG=${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "ECR_URI=${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${GITHUB_SHA}" >> "$GITHUB_ENV"
 
       - name: Login to ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      # Immutable 태그면 같은 SHA 재푸시가 막히므로, "이미 있으면 스킵"이 정석
+      # Immutable 태그면 같은 SHA 재푸시가 막히므로, 이미 있으면 스킵
       - name: Build & Push backend image (tag=GITHUB_SHA, skip if exists)
         shell: bash
         run: |
@@ -59,7 +57,6 @@ jobs:
             exit 0
           fi
 
-          # Dockerfile은 backend/Dockerfile 을 전제로 함
           docker build -t "${ECR_URI}:${IMAGE_TAG}" ./backend
           docker push "${ECR_URI}:${IMAGE_TAG}"
 
@@ -76,7 +73,6 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --comment "FanLink deploy(dev) ${IMAGE_TAG}" \
             --parameters commands="[
-              \"set -euo pipefail\",
               \"sudo bash -lc '/opt/fanlink/deploy.sh ${IMAGE_TAG}'\"
             ]" \
             --query "Command.CommandId" \
@@ -85,7 +81,7 @@ jobs:
           echo "command_id=${CMD_ID}" >> "$GITHUB_OUTPUT"
           echo "[INFO] SSM CommandId=${CMD_ID}"
 
-      # ✅ 여기 핵심: SSM이 실패해도 stdout/stderr를 반드시 출력한다
+      # ✅ 실패해도 stdout/stderr 무조건 출력
       - name: Fetch SSM Result (always print stdout/stderr)
         shell: bash
         run: |


### PR DESCRIPTION
SSM AWS-RunShellScript 문서는 기본 셸이 /bin/sh(dash) 인 경우가 많음.
dash는 set -o pipefail을 지원 안 해서:

set: Illegal option -o pipefail

이렇게 바로 죽은 것
즉 배포 자체 문제가 아니라 “첫 줄 set 옵션이 sh에 안 맞아서” 실패.