### PR TITLE
fix: 코드 상 빈 충돌 지점 수정.

### DIFF
--- a/backend/src/main/java/org/example/backend/ivs/event/IvsRecordingEventListener.java
+++ b/backend/src/main/java/org/example/backend/ivs/event/IvsRecordingEventListener.java
@@ -11,6 +11,7 @@ import org.example.backend.replay.entity.Replay;
 import org.example.backend.replay.entity.ReplayAccessType;
 import org.example.backend.replay.entity.ReplayStatus;
 import org.example.backend.replay.repository.ReplayRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,7 @@ public class IvsRecordingEventListener {
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
+    @Qualifier("ivsRecordingSqsClient")
     private final SqsClient sqsClient;
     private final IvsRecordingEventProperties properties;
     private final LiveSessionRepository liveSessionRepository;

--- a/backend/src/main/java/org/example/backend/replay/event/MediaConvertEventListener.java
+++ b/backend/src/main/java/org/example/backend/replay/event/MediaConvertEventListener.java
@@ -9,6 +9,7 @@ import org.example.backend.replay.entity.Replay;
 import org.example.backend.replay.entity.ReplayStatus;
 import org.example.backend.replay.repository.ReplayRepository;
 import org.example.backend.replay.service.MediaConvertJobService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -30,6 +31,7 @@ public class MediaConvertEventListener {
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
+    @Qualifier("mediaConvertSqsClient")
     private final SqsClient sqsClient;
     private final MediaConvertProperties properties;
     private final ReplayRepository replayRepository;


### PR DESCRIPTION
수정수정. 빈 충돌 지점 부분 수리 완료

수정한 부분
MediaConvertEventListener
- 문제: SqsClient 빈이 ivsRecordingSqsClient, mediaConvertSqsClient 두 개인데, 여기서는 구분 없이 주입받고 있음.
→ IVS/MediaConvert 둘 다 활성화되면 “required a single bean, but 2 were found” 발생 가능.
- 조치: SqsClient 필드에 @Qualifier("mediaConvertSqsClient") 추가함.

IvsRecordingEventListene
- 문제 : IvsRecordingEventListener가 SQS 클라이언트를 주입받을 때 후보 빈이 둘이라 충돌
- 해결 : IvsRecordingEventListener의 SqsClient 필드에 @Qualifier("ivsRecordingSqsClient")를 붙여서, 같은 타입의 빈이 둘일 때 IVS용 SQS 클라이언트만 주입되도록 함.