### PR TITLE
fix: Lombok @RequiredArgsConstructor로 만든 생성자에는 필드에 붙인 @Qualifier가 생성자…

### DIFF
--- a/backend/src/main/java/org/example/backend/ivs/event/IvsRecordingEventListener.java
+++ b/backend/src/main/java/org/example/backend/ivs/event/IvsRecordingEventListener.java
@@ -2,7 +2,6 @@ package org.example.backend.ivs.event;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.ivs.config.IvsRecordingEventProperties;
 import org.example.backend.live_session.entity.LiveSession;
@@ -28,18 +27,29 @@ import java.util.Optional;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "ivs.recording-events", name = "enabled", havingValue = "true")
 public class IvsRecordingEventListener {
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
-    @Qualifier("ivsRecordingSqsClient")
     private final SqsClient sqsClient;
     private final IvsRecordingEventProperties properties;
     private final LiveSessionRepository liveSessionRepository;
     private final ReplayRepository replayRepository;
     private final ObjectMapper objectMapper;
+
+    public IvsRecordingEventListener(
+            @Qualifier("ivsRecordingSqsClient") SqsClient sqsClient,
+            IvsRecordingEventProperties properties,
+            LiveSessionRepository liveSessionRepository,
+            ReplayRepository replayRepository,
+            ObjectMapper objectMapper) {
+        this.sqsClient = sqsClient;
+        this.properties = properties;
+        this.liveSessionRepository = liveSessionRepository;
+        this.replayRepository = replayRepository;
+        this.objectMapper = objectMapper;
+    }
 
     // IVS 녹화 이벤트 SQS를 폴링한다.
     @Scheduled(fixedDelayString = "${ivs.recording-events.poll-fixed-delay-ms:5000}")

--- a/backend/src/main/java/org/example/backend/replay/event/MediaConvertEventListener.java
+++ b/backend/src/main/java/org/example/backend/replay/event/MediaConvertEventListener.java
@@ -2,7 +2,6 @@ package org.example.backend.replay.event;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.replay.config.MediaConvertProperties;
 import org.example.backend.replay.entity.Replay;
@@ -25,18 +24,29 @@ import java.util.Optional;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "mediaconvert.events", name = "enabled", havingValue = "true")
 public class MediaConvertEventListener {
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
-    @Qualifier("mediaConvertSqsClient")
     private final SqsClient sqsClient;
     private final MediaConvertProperties properties;
     private final ReplayRepository replayRepository;
     private final MediaConvertJobService jobService;
     private final ObjectMapper objectMapper;
+
+    public MediaConvertEventListener(
+            @Qualifier("mediaConvertSqsClient") SqsClient sqsClient,
+            MediaConvertProperties properties,
+            ReplayRepository replayRepository,
+            MediaConvertJobService jobService,
+            ObjectMapper objectMapper) {
+        this.sqsClient = sqsClient;
+        this.properties = properties;
+        this.replayRepository = replayRepository;
+        this.jobService = jobService;
+        this.objectMapper = objectMapper;
+    }
 
     // MediaConvert 완료 이벤트 SQS를 폴링한다.
     @Scheduled(fixedDelayString = "${mediaconvert.events.poll-fixed-delay-ms:5000}")


### PR DESCRIPTION
Lombok @RequiredArgsConstructor로 만든 생성자에는 필드에 붙인 @Qualifier가 생성자 파라미터로 전달되지 않아, Spring이 어떤 SqsClient 빈을 넣어야 할지 구분하지 못했음.

@RequiredArgsConstructor 제거

생성자를 직접 선언하고, SqsClient 파라미터에만 @Qualifier("...") 지정
- IvsRecordingEventListener: @Qualifier("ivsRecordingSqsClient")
- MediaConvertEventListener: @Qualifier("mediaConvertSqsClient")