### PR TITLE
fix: 백엔드에서 프론트 origin(예: https://fan-link-project.vercel.app) 허용

### DIFF
--- a/backend/src/main/java/org/example/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/global/config/SecurityConfig.java
@@ -152,7 +152,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "https://fan-link-project.vercel.app"
+        ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
백엔드에서 프론트 origin(예: https://fan-link-project.vercel.app) 허용