### PR TITLE
fix: .catch() 제거 후 player.play()만 호출(프론트)

### DIFF
--- a/frontend/components/ivs/IvsPlayer.jsx
+++ b/frontend/components/ivs/IvsPlayer.jsx
@@ -59,7 +59,8 @@ export default function IvsPlayer({ playbackUrl, token, className = "", videoPro
                 : playbackUrl;
 
             player.load(urlToLoad);
-            player.play().catch(() => {});
+            // IVS Player play() returns void (not Promise). Errors are handled via PlayerEventType.ERROR listener.
+            player.play();
 
             playerRef.current = player;
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><section id="markdown-section-af28be7b-3a15-4ed5-b912-ae8d4a131b46-13" class="markdown-section chat-fade-in" data-markdown-raw="

## 정리" data-section-index="13" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="animation: 0.25s ease 0s 1 normal none running fade-in; font-weight: 600 !important; font-size: 1.3em; line-height: 1.25; margin-bottom: 10px; margin-top: 20px;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">정리</span></h2></section><div class="monaco-scrollable-element markdown-table-container is-scrollable-right" role="presentation" style="scrollbar-width: none; overflow: hidden; color: rgb(204, 204, 204); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; margin: 1em 0px; width: fit-content; max-width: 100%; border-color: color(srgb 0.8 0.8 0.8 / 0.08); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px;"><div class="markdown-table-wrapper" style="--fade-start: rgba(0,0,0,.25); --fade-end: #000; --markdown-table-fade-width: 10px; mask-image: linear-gradient(to right, rgb(0, 0, 0) calc(100% - 10px), rgba(0, 0, 0, 0.25) 100%); --mask: linear-gradient(to right,#000 calc(100% - 10px),rgba(0,0,0,.25) 100%); overflow: hidden;">
구분 | 내용
-- | --
근본 원인 | IVS Player play()는 void를 반환하는데, Promise를 반환한다고 가정하고 .catch()를 호출함
수정 | .catch() 제거 후 player.play()만 호출
임시방편 여부 | 아님. API 스펙에 맞는 올바른 사용 방식으로 수정한 것임

</div></div><!--EndFragment-->
</body>
</html>