### PR TITLE
✨ feat: 무료/유료 라이브 알림 대상 정책 분기 처리 및 라이브 알림 라우팅 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/live_session/service/LiveSessionService.java
+++ b/backend/src/main/java/org/example/backend/live_session/service/LiveSessionService.java
@@ -16,13 +16,16 @@ import org.example.backend.notification.service.NotificationService;
 import org.example.backend.live_session.event.LiveEndedEvent;
 import org.example.backend.subscription.repository.SubscriptionRepository;
 import org.example.backend.user.entity.User;
+import org.example.backend.user.repository.FollowRepository;
 import org.example.backend.user.enums.UserRole;
 import org.example.backend.user.repository.UserRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.Set;
 
 import java.time.Instant;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
@@ -36,6 +39,7 @@ public class LiveSessionService {
 	private final LiveSessionRepository liveSessionRepository;
 	private final NotificationService notificationService;
 	private final SubscriptionRepository subscriptionRepository;
+	private final FollowRepository followRepository;
 	private final ApplicationEventPublisher eventPublisher;
 	private final UserRepository userRepository;
 
@@ -170,27 +174,42 @@ public class LiveSessionService {
 	}
 
 	/**
-	 * 라이브 시작 알림 (구독 팬들에게 SSE 발송)
-	 * - receiverId: 구독 중인 팬 userId
-	 * - senderId: 아티스트 userId
+	 * 라이브 시작 알림 (SSE 발송)
+	 * - 유료 라이브: 구독자에게만
+	 * - 무료 라이브: 팔로워 + 구독자 모두 (중복 제거)
 	 */
 	private void notifyLiveStarted(User artist, LiveSession session) {
-		List<Long> fanIds = subscriptionRepository.findActiveSubscriberUserIdsByArtistId(
+		boolean isPaidLive = session != null && session.isPaid();
+
+		Set<Long> targetUserIds = new LinkedHashSet<>();
+		List<Long> subscriberUserIds = subscriptionRepository.findActiveSubscriberUserIdsByArtistId(
 			session.getArtistId(),
 			Instant.now()
 		);
+		if (subscriberUserIds != null) {
+			for (Long id : subscriberUserIds) if (id != null) targetUserIds.add(id);
+		}
+		if (!isPaidLive) {
+			List<Long> followerUserIds = followRepository.findFollowerUserIdsByArtistId(session.getArtistId());
+			if (followerUserIds != null) {
+				for (Long id : followerUserIds) if (id != null) targetUserIds.add(id);
+			}
+		}
+		if (targetUserIds.isEmpty()) return;
 
 		String title = session.getTitle();
+		Long sessionId = session.getId();
+
 		String shortTitle = (title != null && title.length() > 20) ? title.substring(0, 20) + "…" : title;
 
-		for (Long fanId : fanIds) {
+		for (Long fanId : targetUserIds) {
 			NotificationSendRequest notificationRequest = NotificationSendRequest.builder()
 				.senderId(artist.getId())
 				.receiverId(fanId)
+				.targetId(sessionId)
 				.type(NotificationType.LIVE_STARTED)
 				.content(artist.getNickname() + " 님이 라이브를 시작했어요!" + " <" + shortTitle + ">")
 				.build();
-			// DB 저장 + SSE 발송 (DM과 동일)
 			notificationService.sendNotification(notificationRequest);
 		}
 	}

--- a/backend/src/main/java/org/example/backend/notification/dto/request/NotificationSendRequest.java
+++ b/backend/src/main/java/org/example/backend/notification/dto/request/NotificationSendRequest.java
@@ -13,6 +13,7 @@ import org.example.backend.notification.entity.NotificationType;
 @Builder
 public class NotificationSendRequest {
     private Long receiverId;
+	private Long targetId;
     private Long senderId;
     private NotificationType type;
     private String content;

--- a/backend/src/main/java/org/example/backend/notification/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/org/example/backend/notification/dto/response/NotificationResponse.java
@@ -35,6 +35,8 @@ public class NotificationResponse {
     private Instant createdAt;
     /** DM 알림 시 해당 아티스트 roomId. ARTIST_MESSAGE, FAN_MESSAGE에서만 사용. */
     private Long roomId;
+    /** 알림 클릭 시 이동할 대상 ID (예: LIVE_STARTED → liveSessionId) */
+    private Long targetId;
 
     public static NotificationResponse from(Notification n) {
         return from(n, null);
@@ -48,6 +50,7 @@ public class NotificationResponse {
                 .isRead(n.isRead())
                 .createdAt(n.getCreatedAt())
                 .roomId(roomId)
+                .targetId(n.getTargetId())
                 .build();
     }
 }

--- a/backend/src/main/java/org/example/backend/notification/entity/Notification.java
+++ b/backend/src/main/java/org/example/backend/notification/entity/Notification.java
@@ -30,6 +30,9 @@ public class Notification {
 
     private String content;  // 메시지 내용
 
+    /** 알림 클릭 시 이동할 대상 ID (예: LIVE_STARTED → liveSessionId) */
+    private Long targetId;
+
     @Builder.Default
     private boolean isRead = false;
 

--- a/backend/src/main/java/org/example/backend/notification/service/NotificationService.java
+++ b/backend/src/main/java/org/example/backend/notification/service/NotificationService.java
@@ -103,6 +103,7 @@ public class NotificationService {
                 .sender(sender)
                 .type(request.getType())
                 .content(request.getContent())
+                .targetId(request.getTargetId())
                 .build();
 
         notificationRepository.save(notification);

--- a/backend/src/main/java/org/example/backend/user/repository/FollowRepository.java
+++ b/backend/src/main/java/org/example/backend/user/repository/FollowRepository.java
@@ -25,6 +25,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     long countByArtist(User artist);
 
+    @Query("SELECT f.follower.id FROM Follow f WHERE f.artist.id = :artistId")
+    List<Long> findFollowerUserIdsByArtistId(@Param("artistId") Long artistId);
+
     // 아티스트/그룹의 일별 신규 팔로워 수 (그래프용)
     @Query(value = """
         select date(f.created_at) as date, count(*) as count

--- a/frontend/app/notifications/page.js
+++ b/frontend/app/notifications/page.js
@@ -49,8 +49,12 @@ function formatTimestamp(dateStr) {
 }
 
 function getLink(notification) {
-  const { type, roomId } = notification;
-  if (type === "LIVE_STARTED") return "/live";
+  const { type, roomId, targetId } = notification;
+  if (type === "LIVE_STARTED") {
+    if (targetId != null && targetId !== "") return `/live/${targetId}`;
+    console.warn("[notifications] LIVE_STARTED 알림에 targetId가 없어 라우팅하지 않습니다.", notification);
+    return "#";
+  }
   if (type === "ARTIST_MESSAGE" || type === "FAN_MESSAGE") {
     return roomId ? `/dm/fan?roomId=${roomId}` : "/dm/fan";
   }


### PR DESCRIPTION
## 🎯 작업 영역
- [x] BE (Backend)
- [x] FE (Frontend)


## 🛠 작업 사항
- 라이브 세션 생성 시 알림 발송 대상 정책을 라이브 유형에 따라 분기하도록 수정
- **무료 라이브** → 아티스트 팔로워 전체 알림
- **유료 라이브** → 기존과 동일하게 유료 구독자 알림
- 알림 대상 조회 로직 보완


## 📸 스크린샷 (선택)

## 📚 관련 이슈
- Closes #211
- Closes #


## ✅ 체크리스트
### 공통
- [x] 코드가 정상적으로 컴파일/빌드 되는가?
- [x] 변경 사항에 대한 테스트를 진행했는가?
- [x] 불필요한 로그(System.out.println 등)나 주석을 제거했는가?

### 특이 사항
- [ ] (백엔드) Swagger/API 문서를 현행화했는가?
- [ ] (공통) 새로운 환경 변수(application.yml, .env)가 필요한가?