### PR TITLE
front: 프론트 코드 추가.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ deploy.sh
 *.swp
 *.pem
 README.md
+docs/TROUBLESHOOTING.md
 backend/src/main/java/org/example/backend/replay/README2.md
 backend/src/main/java/org/example/backend/media_asset/README.md
 backend/src/main/java/org/example/backend/music_video/README.md

--- a/backend/src/main/java/org/example/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/global/config/SecurityConfig.java
@@ -109,6 +109,10 @@ public class SecurityConfig {
                     .permitAll()
 
 				.requestMatchers(GET, "/api/concerts/**").permitAll()
+                    // Replay 목록·단건 (아티스트별 공개 조회)
+                    .requestMatchers(GET, "/api/replays").permitAll()
+                    .requestMatchers(GET, "/api/replays/candidates").authenticated()
+                    .requestMatchers(GET, "/api/replays/*").permitAll()
 
                 // 관리자
                 .requestMatchers("/api/admin/**")

--- a/backend/src/main/java/org/example/backend/media_asset/service/MediaAssetService.java
+++ b/backend/src/main/java/org/example/backend/media_asset/service/MediaAssetService.java
@@ -25,7 +25,9 @@ import org.example.backend.replay.service.MediaConvertJobService;
 import org.example.backend.replay.entity.ReplayStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.example.backend.user.entity.User;
 import org.example.backend.user.enums.UserRole;
+import org.example.backend.user.repository.UserRepository;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -51,6 +53,8 @@ public class MediaAssetService {
     private final VideoMetadataExtractor videoMetadataExtractor;
     private final ReplayRepository replayRepository;
     private final MediaConvertJobService mediaConvertJobService;
+    private final ArtistPermissionService artistPermissionService;
+    private final UserRepository userRepository;
 
     // 업로드용 presigned URL을 배치 발급하고 INITIATED 상태를 저장한다.
     @Transactional
@@ -231,6 +235,46 @@ public class MediaAssetService {
         }
         if (mediaAsset.getStatus() != MediaAssetStatus.READY) {
             throw new MediaAssetException(MediaAssetErrorCode.INVALID_MEDIA_ASSET_STATUS, "업로드가 완료된 프로필 이미지만 사용할 수 있습니다.");
+        }
+        return buildCdnUrl(mediaAsset.getObjectKey());
+    }
+
+    /**
+     * 아티스트 프로필 이미지용 MediaAsset의 공개 CDN URL을 반환한다.
+     * 소유자가 해당 아티스트 페이지를 관리할 수 있는 경우에만 허용.
+     */
+    @Transactional(readOnly = true)
+    public String getPublicUrlForArtistProfileImage(Long mediaAssetId, Long artistId) {
+        MediaAsset mediaAsset = mediaAssetRepository.findById(mediaAssetId)
+                .orElseThrow(() -> new MediaAssetException(MediaAssetErrorCode.MEDIA_ASSET_NOT_FOUND));
+        if (mediaAsset.getCategory() != MediaAssetCategory.PROFILE_IMAGE) {
+            throw new MediaAssetException(MediaAssetErrorCode.MEDIA_ASSET_ACCESS_DENIED, "프로필 이미지가 아닌 미디어입니다.");
+        }
+        if (mediaAsset.getStatus() != MediaAssetStatus.READY) {
+            throw new MediaAssetException(MediaAssetErrorCode.INVALID_MEDIA_ASSET_STATUS, "업로드가 완료된 프로필 이미지만 사용할 수 있습니다.");
+        }
+        Long ownerUserId = mediaAsset.getOwnerUserId();
+        User owner = userRepository.findById(ownerUserId).orElse(null);
+        UserRole ownerRole = owner != null ? owner.getRole() : null;
+        if (!artistPermissionService.canManagePage(artistId, ownerUserId, ownerRole, true)) {
+            throw new MediaAssetException(MediaAssetErrorCode.MEDIA_ASSET_ACCESS_DENIED);
+        }
+        return buildCdnUrl(mediaAsset.getObjectKey());
+    }
+
+    /**
+     * 아티스트 커버 이미지용 MediaAsset의 공개 CDN URL을 반환한다.
+     * ARTIST_COVER_IMAGE 카테고리 및 아티스트 관리 권한 검증 후 URL을 생성한다.
+     */
+    @Transactional(readOnly = true)
+    public String getPublicUrlForArtistCover(Long mediaAssetId, Long artistId) {
+        MediaAsset mediaAsset = mediaAssetRepository.findById(mediaAssetId)
+                .orElseThrow(() -> new MediaAssetException(MediaAssetErrorCode.MEDIA_ASSET_NOT_FOUND));
+        if (mediaAsset.getCategory() != MediaAssetCategory.ARTIST_COVER_IMAGE) {
+            throw new MediaAssetException(MediaAssetErrorCode.MEDIA_ASSET_ACCESS_DENIED, "커버 이미지가 아닌 미디어입니다.");
+        }
+        if (mediaAsset.getStatus() != MediaAssetStatus.READY) {
+            throw new MediaAssetException(MediaAssetErrorCode.INVALID_MEDIA_ASSET_STATUS, "업로드가 완료된 커버 이미지만 사용할 수 있습니다.");
         }
         return buildCdnUrl(mediaAsset.getObjectKey());
     }

--- a/backend/src/main/java/org/example/backend/replay/controller/ReplayController.java
+++ b/backend/src/main/java/org/example/backend/replay/controller/ReplayController.java
@@ -31,6 +31,14 @@ public class ReplayController {
     private final ReplayQueryService replayQueryService;
     private final ReplayCommandService replayCommandService;
 
+    // 아티스트별 발행된 Replay 목록을 조회한다. (공개용)
+    @GetMapping
+    public ResponseEntity<List<ReplayResponse>> listByArtist(
+            @RequestParam("artistId") Long artistId
+    ) {
+        return ResponseEntity.ok(replayQueryService.listByArtist(artistId));
+    }
+
     // Replay 후보 목록을 조회한다.
     @GetMapping("/candidates")
     public ResponseEntity<List<ReplayCandidateResponse>> listCandidates(

--- a/backend/src/main/java/org/example/backend/replay/dto/ReplayPublishRequest.java
+++ b/backend/src/main/java/org/example/backend/replay/dto/ReplayPublishRequest.java
@@ -13,6 +13,7 @@ public record ReplayPublishRequest(
         @NotNull
         ReplayAccessType accessType,
         @Size(max = 200)
-        String title
+        String title,
+        Long thumbnailMediaAssetId
 ) {
 }

--- a/backend/src/main/java/org/example/backend/replay/dto/ReplayResponse.java
+++ b/backend/src/main/java/org/example/backend/replay/dto/ReplayResponse.java
@@ -14,6 +14,7 @@ public record ReplayResponse(
         ReplayStatus status,
         String playbackUrl,
         String playbackPathPattern,
+        String thumbnailUrl,
         Instant createdAt,
         Instant publishedAt
 ) {

--- a/backend/src/main/java/org/example/backend/replay/service/ReplayCommandService.java
+++ b/backend/src/main/java/org/example/backend/replay/service/ReplayCommandService.java
@@ -2,6 +2,12 @@ package org.example.backend.replay.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.media_asset.config.AwsProperties;
+import org.example.backend.media_asset.entity.MediaAsset;
+import org.example.backend.media_asset.entity.MediaAssetCategory;
+import org.example.backend.media_asset.entity.MediaAssetStatus;
+import org.example.backend.media_asset.exception.MediaAssetErrorCode;
+import org.example.backend.media_asset.exception.MediaAssetException;
+import org.example.backend.media_asset.repository.MediaAssetRepository;
 import org.example.backend.replay.dto.ReplayAccessResponse;
 import org.example.backend.replay.dto.ReplayAccessResult;
 import org.example.backend.replay.dto.ReplayPublishRequest;
@@ -36,6 +42,7 @@ import java.util.List;
 public class ReplayCommandService {
 
     private final ReplayRepository replayRepository;
+    private final MediaAssetRepository mediaAssetRepository;
     @Qualifier("replayLiveSessionServiceGateway")
     private final LiveSessionGateway liveSessionGateway;
     private final ArtistPermissionService artistPermissionService;
@@ -83,6 +90,18 @@ public class ReplayCommandService {
                 now
         );
         replayRepository.save(replay);
+
+        if (request.thumbnailMediaAssetId() != null) {
+            MediaAsset mediaAsset = mediaAssetRepository.findById(request.thumbnailMediaAssetId())
+                    .orElseThrow(() -> new MediaAssetException(MediaAssetErrorCode.MEDIA_ASSET_NOT_FOUND));
+            if (mediaAsset.getCategory() != MediaAssetCategory.REPLAY_THUMBNAIL) {
+                throw new MediaAssetException(MediaAssetErrorCode.MEDIA_ASSET_ACCESS_DENIED, "다시보기 썸네일이 아닌 미디어입니다.");
+            }
+            if (mediaAsset.getStatus() != MediaAssetStatus.READY) {
+                throw new MediaAssetException(MediaAssetErrorCode.INVALID_MEDIA_ASSET_STATUS, "업로드가 완료된 썸네일만 사용할 수 있습니다.");
+            }
+            replay.updateThumbnailKey(mediaAsset.getObjectKey());
+        }
 
         String playbackUrl = playbackUrlCalculator.buildPlaybackUrl(awsProperties.getCloudfront().getDomain(), replay);
         return new ReplayPublishResponse(

--- a/backend/src/main/java/org/example/backend/replay/service/ReplayQueryService.java
+++ b/backend/src/main/java/org/example/backend/replay/service/ReplayQueryService.java
@@ -5,6 +5,7 @@ import org.example.backend.media_asset.config.AwsProperties;
 import org.example.backend.replay.dto.ReplayCandidateResponse;
 import org.example.backend.replay.dto.ReplayResponse;
 import org.example.backend.replay.entity.Replay;
+import org.example.backend.replay.entity.ReplayStatus;
 import org.example.backend.replay.exception.ReplayErrorCode;
 import org.example.backend.replay.exception.ReplayException;
 import org.example.backend.replay.gateway.LiveSessionGateway;
@@ -32,6 +33,15 @@ public class ReplayQueryService {
     private final PlaybackUrlCalculator playbackUrlCalculator;
     private final AwsProperties awsProperties;
 
+    // 아티스트별 발행된 Replay 목록을 조회한다. (공개용)
+    public List<ReplayResponse> listByArtist(Long artistId) {
+        List<Replay> replays = replayRepository.findAllByArtistIdOrderByCreatedAtDesc(artistId);
+        return replays.stream()
+                .filter(r -> r.getStatus() == ReplayStatus.PUBLISHED)
+                .map(this::toReplayResponse)
+                .toList();
+    }
+
     // Replay 후보 목록을 조회한다. 방송 주체(session.artistId)만 발행 가능하므로 본인 채널 세션만 반환.
     public List<ReplayCandidateResponse> listCandidates(Long artistId, Long userId, UserRole role) {
         if (!artistPermissionService.canManagePage(artistId, userId, role, true)) {
@@ -49,8 +59,13 @@ public class ReplayQueryService {
     public ReplayResponse getReplay(Long replayId) {
         Replay replay = replayRepository.findById(replayId)
                 .orElseThrow(() -> new ReplayException(ReplayErrorCode.REPLAY_NOT_FOUND));
+        return toReplayResponse(replay);
+    }
+
+    private ReplayResponse toReplayResponse(Replay replay) {
         String playbackUrl = playbackUrlCalculator.buildPlaybackUrl(awsProperties.getCloudfront().getDomain(), replay);
         String pattern = playbackUrlCalculator.buildPlaybackPathPattern(awsProperties.getCloudfront().getDomain(), replay);
+        String thumbnailUrl = buildThumbnailUrl(replay);
         return new ReplayResponse(
                 replay.getId(),
                 replay.getArtistId(),
@@ -59,9 +74,23 @@ public class ReplayQueryService {
                 replay.getStatus(),
                 playbackUrl,
                 pattern,
+                thumbnailUrl,
                 replay.getCreatedAt(),
                 replay.getPublishedAt()
         );
+    }
+
+    private String buildThumbnailUrl(Replay replay) {
+        String key = replay.getThumbnailKey();
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+        String domain = awsProperties.getCloudfront().getDomain();
+        if (domain == null || domain.isBlank()) {
+            return null;
+        }
+        domain = domain.replace("https://", "").replace("http://", "").trim();
+        return "https://" + domain + "/" + (key.startsWith("/") ? key.substring(1) : key);
     }
 
     // 후보 라이브 세션 응답을 구성한다.

--- a/backend/src/main/java/org/example/backend/user/dto/request/ArtistProfileUpdateRequest.java
+++ b/backend/src/main/java/org/example/backend/user/dto/request/ArtistProfileUpdateRequest.java
@@ -10,6 +10,8 @@ public record ArtistProfileUpdateRequest(
         @Size(max = 1000) String bio,
         String profileImageUrl,
         String bannerImageUrl,
+        Long profileImageMediaAssetId,
+        Long bannerImageMediaAssetId,
         String officialLinks  // JSON 예: {"instagram":"url","youtube":"url"}
 ) {
 }

--- a/backend/src/main/java/org/example/backend/user/service/ArtistService.java
+++ b/backend/src/main/java/org/example/backend/user/service/ArtistService.java
@@ -17,6 +17,7 @@ import org.example.backend.product.repository.ProductRepository;
 import org.example.backend.settlement.repository.SettlementPendingRepository;
 import org.example.backend.settlement.service.SettlementDashboardService;
 import org.example.backend.user.exception.UserException;
+import org.example.backend.media_asset.service.MediaAssetService;
 import org.example.backend.user.repository.FollowRepository;
 import org.example.backend.user.repository.GroupMemberRepository;
 import org.example.backend.user.repository.UserRepository;
@@ -44,6 +45,7 @@ public class ArtistService {
     private final GroupMemberRepository groupMemberRepository;
     private final ArtistPostRepository artistPostRepository;
     private final UserRepository userRepository;
+    private final MediaAssetService mediaAssetService;
     private final SettlementDashboardService settlementDashboardService;
     private final SettlementPendingRepository settlementPendingRepository;
     private final ProductRepository productRepository;
@@ -184,10 +186,18 @@ public class ArtistService {
         if (request.bio() != null) {
             user.setBio(request.bio());
         }
-        if (request.profileImageUrl() != null) {
+        if (request.profileImageMediaAssetId() != null) {
+            String profileUrl = mediaAssetService.getPublicUrlForArtistProfileImage(
+                    request.profileImageMediaAssetId(), user.getId());
+            user.setProfileImageUrl(profileUrl);
+        } else if (request.profileImageUrl() != null) {
             user.setProfileImageUrl(request.profileImageUrl());
         }
-        if (request.bannerImageUrl() != null) {
+        if (request.bannerImageMediaAssetId() != null) {
+            String bannerUrl = mediaAssetService.getPublicUrlForArtistCover(
+                    request.bannerImageMediaAssetId(), user.getId());
+            user.setBannerImageUrl(bannerUrl);
+        } else if (request.bannerImageUrl() != null) {
             user.setBannerImageUrl(request.bannerImageUrl());
         }
         if (request.officialLinks() != null) {

--- a/frontend/app/artist-console/ArtistConsoleGuard.jsx
+++ b/frontend/app/artist-console/ArtistConsoleGuard.jsx
@@ -27,6 +27,7 @@ const GROUP_MEMBER_ALLOWED = [
   "/artist-console/posts",
   "/artist-console/live",
   "/artist-console/settlement",
+  "/artist-console/music-videos",
 ];
 
 function isAllowedForGroupMember(pathname) {

--- a/frontend/app/artist-console/live/page.js
+++ b/frontend/app/artist-console/live/page.js
@@ -11,6 +11,8 @@ import Button from "@/components/ui/Button";
 
 import { apiGet, getToken, normalizeToken, WS_CHAT_URL } from "@/lib/api";
 import { getCandidates, publish, ReplayAccessType } from "@/lib/replayApi";
+import { useMediaUpload } from "@/lib/useMediaUpload";
+import { MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
 
 export default function ArtistLivePage() {
     // --- artist context (현재 로그인 계정 = groupId 또는 본인 id) ---
@@ -125,7 +127,17 @@ export default function ArtistLivePage() {
         liveSessionId: "",
         accessType: ReplayAccessType.FREE,
         title: "",
+        thumbnailMediaAssetId: null,
+        thumbnailPreviewUrl: null,
     });
+
+    const thumbnailPresignItem = {
+        category: MediaAssetCategory.REPLAY_THUMBNAIL,
+        scope: MediaAssetScope.PUBLIC,
+        artistId: artistId ?? undefined,
+        replayIdOrTemp: "tmp_publish",
+    };
+    const { upload: uploadThumbnail } = useMediaUpload(thumbnailPresignItem);
 
     const [publishing, setPublishing] = useState(false);
     const [publishedReplay, setPublishedReplay] = useState(null);
@@ -162,6 +174,7 @@ export default function ArtistLivePage() {
                 liveSessionId,
                 accessType: publishForm.accessType,
                 title: publishForm.title || null,
+                thumbnailMediaAssetId: publishForm.thumbnailMediaAssetId || null,
             });
 
             setPublishedReplay(res);
@@ -169,6 +182,8 @@ export default function ArtistLivePage() {
                 liveSessionId: "",
                 accessType: ReplayAccessType.FREE,
                 title: "",
+                thumbnailMediaAssetId: null,
+                thumbnailPreviewUrl: null,
             });
 
             // 발행 후 리스트도 같이 갱신 (선택)
@@ -450,6 +465,37 @@ export default function ArtistLivePage() {
                             }
                             className="mt-1 w-full bg-[#16102a] border border-white/[0.08] rounded-lg px-3 py-2 text-white"
                         />
+                    </label>
+
+                    <label className="block">
+            <span className="text-[10px] font-black uppercase tracking-widest text-white/55">
+              썸네일 (선택)
+            </span>
+                        <input
+                            type="file"
+                            accept="image/*"
+                            className="hidden"
+                            id="replay-thumbnail-input"
+                            onChange={async (e) => {
+                                const file = e.target.files?.[0];
+                                if (!file || !file.type.startsWith("image/") || !uploadThumbnail) return;
+                                const result = await uploadThumbnail(file);
+                                if (result?.mediaAssetId && result?.url) {
+                                    setPublishForm((f) => ({ ...f, thumbnailMediaAssetId: result.mediaAssetId, thumbnailPreviewUrl: result.url }));
+                                }
+                                e.target.value = "";
+                            }}
+                        />
+                        {publishForm.thumbnailPreviewUrl ? (
+                            <div className="mt-1 relative inline-block">
+                                <img src={publishForm.thumbnailPreviewUrl} alt="썸네일" className="w-full max-w-xs rounded-lg border border-white/10 object-cover aspect-video" />
+                                <button type="button" onClick={() => setPublishForm((f) => ({ ...f, thumbnailMediaAssetId: null, thumbnailPreviewUrl: null }))} className="absolute top-1 right-1 size-6 rounded-full bg-red-500 text-white text-xs">×</button>
+                            </div>
+                        ) : (
+                            <button type="button" onClick={() => document.getElementById("replay-thumbnail-input")?.click()} className="mt-1 py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm">
+                                파일 업로드
+                            </button>
+                        )}
                     </label>
 
                     <Button type="submit" variant="primary" disabled={publishing}>

--- a/frontend/app/artist-console/music-videos/page.js
+++ b/frontend/app/artist-console/music-videos/page.js
@@ -6,11 +6,10 @@ import Surface from "@/components/ui/Surface";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
 import { list, create, remove } from "@/lib/musicVideoApi";
-
-const DEFAULT_ARTIST_ID = 1;
+import { request } from "@/lib/api";
 
 export default function ArtistMusicVideosPage() {
-  const [artistId, setArtistId] = useState(DEFAULT_ARTIST_ID);
+  const [artistId, setArtistId] = useState(null);
   const [videos, setVideos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -19,6 +18,7 @@ export default function ArtistMusicVideosPage() {
   const [submitting, setSubmitting] = useState(false);
 
   const loadList = () => {
+    if (!artistId) return;
     setLoading(true);
     setError(null);
     list(artistId)
@@ -29,6 +29,15 @@ export default function ArtistMusicVideosPage() {
       })
       .finally(() => setLoading(false));
   };
+
+  useEffect(() => {
+    request("/api/artist/mypage")
+      .then((data) => {
+        const id = data?.profile?.groupId ?? data?.profile?.id;
+        setArtistId(id ?? null);
+      })
+      .catch(() => setArtistId(null));
+  }, []);
 
   useEffect(() => {
     loadList();
@@ -79,18 +88,9 @@ export default function ArtistMusicVideosPage() {
         </Button>
       </header>
 
-      <label className="block">
-        <span className="text-[10px] font-black uppercase tracking-widest text-white/55">
-          artistId
-        </span>
-        <input
-          type="number"
-          min="1"
-          value={artistId}
-          onChange={(e) => setArtistId(Number(e.target.value) || 1)}
-          className="mt-1 w-24 bg-[#16102a] border border-white/[0.08] rounded-lg px-3 py-2 text-white"
-        />
-      </label>
+      {!artistId && !loading && (
+        <p className="text-white/55 text-sm">아티스트 정보를 불러오는 중...</p>
+      )}
 
       {error && <p className="text-red-400 text-sm">{error}</p>}
 

--- a/frontend/app/artist-console/page.js
+++ b/frontend/app/artist-console/page.js
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { request } from "@/lib/api";
 import { getDefaultAvatarUrl } from "@/lib/avatar";
+import { useMediaUpload } from "@/lib/useMediaUpload";
+import { MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
 import Surface from "@/components/ui/Surface";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
@@ -116,8 +118,19 @@ export default function ArtistConsolePage() {
     const [newPostContent, setNewPostContent] = useState("");
     const [newPostIsMembershipOnly, setNewPostIsMembershipOnly] = useState(false);
     const [newPostIsNotice, setNewPostIsNotice] = useState(false);
+    const [newPostMediaAssetIds, setNewPostMediaAssetIds] = useState([]);
+    const [newPostAttachmentPreviews, setNewPostAttachmentPreviews] = useState([]);
     const [createPostLoading, setCreatePostLoading] = useState(false);
     const newPostFileInputRef = useRef(null);
+
+    const newPostPresignItem = {
+        category: MediaAssetCategory.POST_IMAGE,
+        scope: MediaAssetScope.PUBLIC,
+        artistId: groupId ?? undefined,
+        postIdOrTemp: "new",
+        attachmentCountInPost: newPostMediaAssetIds.length + 1,
+    };
+    const { upload: uploadNewPostImage } = useMediaUpload(newPostPresignItem);
 
     // 팬 포스트 state
     const [fanPosts, setFanPosts] = useState([]);
@@ -395,7 +408,25 @@ export default function ArtistConsolePage() {
         setNewPostContent("");
         setNewPostIsMembershipOnly(false);
         setNewPostIsNotice(false);
+        setNewPostMediaAssetIds([]);
+        setNewPostAttachmentPreviews([]);
         setShowCreateModal(false);
+    };
+
+    const handleNewPostImageChange = async (e) => {
+        const file = e?.target?.files?.[0];
+        if (!file || !file.type.startsWith("image/") || !uploadNewPostImage) return;
+        const result = await uploadNewPostImage(file);
+        if (result?.mediaAssetId && result?.url) {
+            setNewPostMediaAssetIds((prev) => [...prev, result.mediaAssetId]);
+            setNewPostAttachmentPreviews((prev) => [...prev, { mediaAssetId: result.mediaAssetId, url: result.url }]);
+        }
+        e.target.value = "";
+    };
+
+    const removeNewPostImage = (mediaAssetId) => {
+        setNewPostMediaAssetIds((prev) => prev.filter((id) => id !== mediaAssetId));
+        setNewPostAttachmentPreviews((prev) => prev.filter((p) => p.mediaAssetId !== mediaAssetId));
     };
 
     // 아티스트 포스트 생성
@@ -411,7 +442,7 @@ export default function ArtistConsolePage() {
                     content: newPostContent.trim(),
                     isMembershipOnly: newPostIsMembershipOnly,
                     isNotice: newPostIsNotice,
-                    mediaAssetIds: [],
+                    mediaAssetIds: newPostMediaAssetIds,
                 },
             });
             const groupAvatar = myProfile?.profileImageUrl || "";
@@ -524,6 +555,7 @@ export default function ArtistConsolePage() {
                         { id: "FAN_POSTS", label: "Fan Posts" },
                         { id: "LIVE", label: "Live History" },
                         { id: "CONCERTS", label: "Concerts" },
+                        { id: "MV", label: "MV", href: "/artist-console/music-videos" },
                     ].map((tab) =>
                         tab.href ? (
                             <Link
@@ -827,20 +859,36 @@ export default function ArtistConsolePage() {
                             </label>
                         )}
 
-                        {/* 사진 첨부 버튼 */}
+                        {/* 사진 첨부 */}
                         <div className="mt-5">
                             <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
                                 사진 첨부
                             </span>
-                            <input ref={newPostFileInputRef} type="file" accept="image/*" className="hidden" />
-                            <button
-                                type="button"
-                                onClick={() => newPostFileInputRef.current?.click()}
-                                className="w-full py-6 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2"
-                            >
-                                <span className="material-symbols-outlined text-3xl">add_photo_alternate</span>
-                                <span className="text-xs font-bold">클릭하여 사진 추가</span>
-                            </button>
+                            <input ref={newPostFileInputRef} type="file" accept="image/*" className="hidden" onChange={handleNewPostImageChange} />
+                            {newPostAttachmentPreviews.length > 0 ? (
+                                <div className="space-y-3">
+                                    {newPostAttachmentPreviews.map((p) => (
+                                        <div key={p.mediaAssetId} className="relative rounded-2xl overflow-hidden border border-white/[0.08]">
+                                            <img src={p.url} alt="미리보기" className="w-full max-h-48 object-contain bg-black/20" />
+                                            <button type="button" onClick={() => removeNewPostImage(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
+                                                <span className="material-symbols-outlined text-lg">close</span>
+                                            </button>
+                                        </div>
+                                    ))}
+                                    <button type="button" onClick={() => newPostFileInputRef.current?.click()} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm">
+                                        + 추가
+                                    </button>
+                                </div>
+                            ) : (
+                                <button
+                                    type="button"
+                                    onClick={() => newPostFileInputRef.current?.click()}
+                                    className="w-full py-6 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2"
+                                >
+                                    <span className="material-symbols-outlined text-3xl">add_photo_alternate</span>
+                                    <span className="text-xs font-bold">클릭하여 사진 추가</span>
+                                </button>
+                            )}
                         </div>
 
                         {/* 버튼 */}

--- a/frontend/app/artists/[id]/page.js
+++ b/frontend/app/artists/[id]/page.js
@@ -6,8 +6,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import axios from "axios";
 
 // 데이터 및 유틸리티
-import { MOCK_ARTISTS, MOCK_POSTS, MOCK_LIVES } from "@/lib/mockData";
+import { MOCK_ARTISTS, MOCK_POSTS } from "@/lib/mockData";
 import { list as listMusicVideos } from "@/lib/musicVideoApi";
+import { listByArtist as listReplays } from "@/lib/replayApi";
 import { request, apiGet, apiPost, BASE_URL } from "@/lib/api";
 import {
     isUpcoming,
@@ -135,6 +136,8 @@ function ArtistDetailPageInner({ paramsId }) {
     const [liveSessions, setLiveSessions] = useState([]);
     const [liveLoading, setLiveLoading] = useState(false);
     const [liveError, setLiveError] = useState("");
+    const [vodList, setVodList] = useState([]);
+    const [vodLoading, setVodLoading] = useState(false);
 
     // 모달 및 UI 상태
     const [showCreateModal, setShowCreateModal] = useState(false);
@@ -368,7 +371,17 @@ function ArtistDetailPageInner({ paramsId }) {
             .catch(() => setArtistNotices([]));
     }, [groupId, isRealGroup]);
 
-    // 5. MV 탭 활성화 시 로드
+    // 5. LIVE 탭 활성화 시 다시보기(VOD) 목록 로드
+    useEffect(() => {
+        if (activeTab !== "LIVE" || !artist?.backendId) return;
+        setVodLoading(true);
+        listReplays(artist.backendId)
+            .then((list) => setVodList(Array.isArray(list) ? list : []))
+            .catch(() => setVodList([]))
+            .finally(() => setVodLoading(false));
+    }, [activeTab, artist?.backendId]);
+
+    // 6. MV 탭 활성화 시 로드
     useEffect(() => {
         if (activeTab !== "MV" || !artist) return;
         setMusicVideosLoading(true);
@@ -533,11 +546,8 @@ function ArtistDetailPageInner({ paramsId }) {
         { id: "FAN", label: "Fan" },
         { id: "LIVE", label: "Live" },
         { id: "MARKET", label: "Market" },
-        { id: "MV", label: "MV." },
+        { id: "MV", label: "MV" },
     ];
-
-    // VOD (Mock 기반 유지)
-    const vodList = MOCK_LIVES.filter(l => l.artistId === artist.id && (l.status === "ENDED" || l.status === "RECORDED"));
 
     return (
         <div className="flex flex-col min-h-full relative pb-20">
@@ -812,18 +822,20 @@ function ArtistDetailPageInner({ paramsId }) {
 
                             <section>
                                 <h3 className="text-xs font-black text-white/40 mb-6 uppercase tracking-widest">Replay (VOD)</h3>
-                                {vodList.length > 0 ? (
+                                {vodLoading ? (
+                                    <p className="text-white/40 py-12 text-center">로딩 중...</p>
+                                ) : vodList.length > 0 ? (
                                     <div className="grid grid-cols-2 gap-6">
-                                        {vodList.map(vod => (
-                                            <Link key={vod.id} href={`/live/${vod.id}`} className="group">
+                                        {vodList.map((vod) => (
+                                            <Link key={vod.replayId} href={`/live/${vod.replayId}`} className="group">
                                                 <div className="aspect-video rounded-2xl overflow-hidden relative mb-3">
-                                                    <img src={vod.thumbnail} className="w-full h-full object-cover" alt="" />
+                                                    <img src={vod.thumbnailUrl || "https://picsum.photos/seed/vod/800/450"} className="w-full h-full object-cover" alt="" />
                                                     <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/40 transition-opacity">
                                                         <span className="material-symbols-outlined text-white text-5xl">play_circle</span>
                                                     </div>
                                                 </div>
-                                                <h5 className="font-bold text-white truncate">{vod.title}</h5>
-                                                <p className="text-white/40 text-xs mt-1">{vod.startTime}</p>
+                                                <h5 className="font-bold text-white truncate">다시보기</h5>
+                                                <p className="text-white/40 text-xs mt-1">{vod.publishedAt ? new Date(vod.publishedAt).toLocaleDateString("ko-KR") : ""}</p>
                                             </Link>
                                         ))}
                                     </div>

--- a/frontend/app/mypage/page.js
+++ b/frontend/app/mypage/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import axios from "axios";
 import Link from "next/link";
 import Surface from "@/components/ui/Surface";
@@ -8,7 +8,9 @@ import Button from "@/components/ui/Button";
 import SectionTitle from "@/components/ui/SectionTitle";
 import { getDefaultAvatarUrl } from "@/lib/avatar";
 import { redirectToGuestHome } from "@/lib/authRedirect";
-import { BASE_URL } from "@/lib/api";
+import { BASE_URL, request } from "@/lib/api";
+import { useMediaUpload } from "@/lib/useMediaUpload";
+import { MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
 
 function getAuthHeaders() {
   if (typeof window === "undefined") return {};
@@ -58,9 +60,15 @@ export default function MyPage() {
     bio: "",
     profileImageUrl: "",
     bannerImageUrl: "",
+    profileImageMediaAssetId: null,
+    bannerImageMediaAssetId: null,
+    profileImagePreviewUrl: null,
+    bannerImagePreviewUrl: null,
   });
   const [artistProfileEditLoading, setArtistProfileEditLoading] = useState(false);
   const [artistProfileEditMessage, setArtistProfileEditMessage] = useState("");
+  const artistProfileRefInput = useRef(null);
+  const artistBannerRefInput = useRef(null);
 
   const [showOfficialLinksModal, setShowOfficialLinksModal] = useState(false);
   const [officialLinksList, setOfficialLinksList] = useState([]);
@@ -74,6 +82,19 @@ export default function MyPage() {
   const [nicknameEdit, setNicknameEdit] = useState("");
   const [nicknameLoading, setNicknameLoading] = useState(false);
   const [nicknameMessage, setNicknameMessage] = useState("");
+
+  const artistIdForCover = artistProfile?.groupId ?? artistProfile?.id;
+  const profilePresignItem = {
+    category: MediaAssetCategory.PROFILE_IMAGE,
+    scope: MediaAssetScope.PUBLIC,
+  };
+  const coverPresignItem = {
+    category: MediaAssetCategory.ARTIST_COVER_IMAGE,
+    scope: MediaAssetScope.PUBLIC,
+    artistId: artistIdForCover ?? undefined,
+  };
+  const { upload: uploadProfileImage } = useMediaUpload(profilePresignItem);
+  const { upload: uploadCoverImage } = useMediaUpload(coverPresignItem);
 
   useEffect(() => {
     const headers = getAuthHeaders();
@@ -207,24 +228,56 @@ export default function MyPage() {
     setArtistProfileEditMessage("");
     setArtistProfileEditLoading(true);
     try {
-      const headers = getAuthHeaders();
-      const res = await axios.patch(
-        `${BASE_URL}/api/artist/profile`,
-        {
-          bio: artistProfileEdit.bio || null,
-          profileImageUrl: artistProfileEdit.profileImageUrl || null,
-          bannerImageUrl: artistProfileEdit.bannerImageUrl || null,
-        },
-        { headers }
-      );
-      setArtistProfile(res.data ?? artistProfile);
+      const body = {
+        bio: artistProfileEdit.bio || null,
+        profileImageUrl: artistProfileEdit.profileImageMediaAssetId ? null : (artistProfileEdit.profileImageUrl || null),
+        bannerImageUrl: artistProfileEdit.bannerImageMediaAssetId ? null : (artistProfileEdit.bannerImageUrl || null),
+        profileImageMediaAssetId: artistProfileEdit.profileImageMediaAssetId || null,
+        bannerImageMediaAssetId: artistProfileEdit.bannerImageMediaAssetId || null,
+        officialLinks: null,
+      };
+      const res = await request("/api/artist/profile", {
+        method: "PATCH",
+        body,
+      });
+      setArtistProfile(res ?? artistProfile);
       setArtistProfileEditMessage("저장되었습니다.");
       setShowArtistProfileEdit(false);
     } catch (e) {
-      setArtistProfileEditMessage(e.response?.data?.message ?? "저장에 실패했습니다.");
+      setArtistProfileEditMessage(e?.data?.message ?? e?.message ?? "저장에 실패했습니다.");
     } finally {
       setArtistProfileEditLoading(false);
     }
+  };
+
+  const handleArtistProfileImageUpload = async (e) => {
+    const file = e?.target?.files?.[0];
+    if (!file || !file.type.startsWith("image/") || !uploadProfileImage) return;
+    const result = await uploadProfileImage(file);
+    if (result?.mediaAssetId && result?.url) {
+      setArtistProfileEdit((p) => ({
+        ...p,
+        profileImageMediaAssetId: result.mediaAssetId,
+        profileImageUrl: "",
+        profileImagePreviewUrl: result.url,
+      }));
+    }
+    e.target.value = "";
+  };
+
+  const handleArtistBannerUpload = async (e) => {
+    const file = e?.target?.files?.[0];
+    if (!file || !file.type.startsWith("image/") || !uploadCoverImage || !artistIdForCover) return;
+    const result = await uploadCoverImage(file);
+    if (result?.mediaAssetId && result?.url) {
+      setArtistProfileEdit((p) => ({
+        ...p,
+        bannerImageMediaAssetId: result.mediaAssetId,
+        bannerImageUrl: "",
+        bannerImagePreviewUrl: result.url,
+      }));
+    }
+    e.target.value = "";
   };
 
   const OFFICIAL_LINK_TYPES = [
@@ -779,6 +832,10 @@ export default function MyPage() {
                         bio: artistProfile?.bio ?? "",
                         profileImageUrl: artistProfile?.profileImageUrl ?? "",
                         bannerImageUrl: artistProfile?.bannerImageUrl ?? "",
+                        profileImageMediaAssetId: null,
+                        bannerImageMediaAssetId: null,
+                        profileImagePreviewUrl: null,
+                        bannerImagePreviewUrl: null,
                       });
                       setArtistProfileEditMessage("");
                       setShowArtistProfileEdit(true);
@@ -894,23 +951,85 @@ export default function MyPage() {
               />
             </div>
             <div>
-              <label className="text-[10px] font-black uppercase text-white/55 block mb-1">프로필 이미지 URL</label>
+              <label className="text-[10px] font-black uppercase text-white/55 block mb-1">프로필 이미지</label>
+              <input
+                ref={artistProfileRefInput}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleArtistProfileImageUpload}
+              />
+              {artistProfileEdit.profileImagePreviewUrl || artistProfileEdit.profileImageUrl ? (
+                <div className="relative inline-block">
+                  <img
+                    src={artistProfileEdit.profileImagePreviewUrl || artistProfileEdit.profileImageUrl}
+                    alt="프로필 미리보기"
+                    className="size-20 rounded-xl object-cover border border-white/10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setArtistProfileEdit((p) => ({ ...p, profileImagePreviewUrl: null, profileImageMediaAssetId: null, profileImageUrl: "" }))}
+                    className="absolute -top-1 -right-1 size-6 rounded-full bg-red-500 text-white flex items-center justify-center text-xs"
+                  >
+                    ×
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => artistProfileRefInput.current?.click()}
+                  className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 hover:text-violet-300 text-sm"
+                >
+                  파일 업로드
+                </button>
+              )}
               <input
                 type="url"
                 value={artistProfileEdit.profileImageUrl}
-                onChange={(e) => setArtistProfileEdit((p) => ({ ...p, profileImageUrl: e.target.value }))}
-                className="w-full px-4 py-2 rounded-xl bg-[#201a33] text-white border border-white/[0.06] text-sm"
-                placeholder="https://..."
+                onChange={(e) => setArtistProfileEdit((p) => ({ ...p, profileImageUrl: e.target.value, profileImageMediaAssetId: null }))}
+                className="mt-2 w-full px-4 py-2 rounded-xl bg-[#201a33] text-white border border-white/[0.06] text-sm"
+                placeholder="또는 URL 입력"
               />
             </div>
             <div>
-              <label className="text-[10px] font-black uppercase text-white/55 block mb-1">배너 이미지 URL</label>
+              <label className="text-[10px] font-black uppercase text-white/55 block mb-1">배너 이미지</label>
+              <input
+                ref={artistBannerRefInput}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleArtistBannerUpload}
+              />
+              {artistProfileEdit.bannerImagePreviewUrl || artistProfileEdit.bannerImageUrl ? (
+                <div className="relative inline-block">
+                  <img
+                    src={artistProfileEdit.bannerImagePreviewUrl || artistProfileEdit.bannerImageUrl}
+                    alt="배너 미리보기"
+                    className="w-full max-h-24 rounded-xl object-cover border border-white/10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setArtistProfileEdit((p) => ({ ...p, bannerImagePreviewUrl: null, bannerImageMediaAssetId: null, bannerImageUrl: "" }))}
+                    className="absolute top-1 right-1 size-6 rounded-full bg-red-500 text-white flex items-center justify-center text-xs"
+                  >
+                    ×
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => artistBannerRefInput.current?.click()}
+                  className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 hover:text-violet-300 text-sm"
+                >
+                  파일 업로드
+                </button>
+              )}
               <input
                 type="url"
                 value={artistProfileEdit.bannerImageUrl}
-                onChange={(e) => setArtistProfileEdit((p) => ({ ...p, bannerImageUrl: e.target.value }))}
-                className="w-full px-4 py-2 rounded-xl bg-[#201a33] text-white border border-white/[0.06] text-sm"
-                placeholder="https://..."
+                onChange={(e) => setArtistProfileEdit((p) => ({ ...p, bannerImageUrl: e.target.value, bannerImageMediaAssetId: null }))}
+                className="mt-2 w-full px-4 py-2 rounded-xl bg-[#201a33] text-white border border-white/[0.06] text-sm"
+                placeholder="또는 URL 입력"
               />
             </div>
             <div className="flex gap-2 pt-4">

--- a/frontend/app/posts/new/page.js
+++ b/frontend/app/posts/new/page.js
@@ -7,8 +7,9 @@ import Surface from "@/components/ui/Surface";
 import { getDefaultAvatarUrl } from "@/lib/avatar";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
-
-import { BASE_URL } from "@/lib/api";
+import { BASE_URL, request } from "@/lib/api";
+import { useMediaUpload } from "@/lib/useMediaUpload";
+import { MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
 
 function getAuthHeaders() {
   if (typeof window === "undefined") return {};
@@ -21,30 +22,66 @@ export default function NewPostPage() {
   const router = useRouter();
   const [profile, setProfile] = useState(null);
   const [artistId, setArtistId] = useState(null);
+  const [groupId, setGroupId] = useState(null);
   const [content, setContent] = useState("");
-  const [imageFile, setImageFile] = useState(null);
-  const [imagePreview, setImagePreview] = useState(null);
+  const [mediaAssetIds, setMediaAssetIds] = useState([]);
+  const [attachmentPreviews, setAttachmentPreviews] = useState([]);
+  const [submitLoading, setSubmitLoading] = useState(false);
   const fileInputRef = useRef(null);
 
-  const handleImageChange = (e) => {
+  const presignItem = {
+    category: MediaAssetCategory.POST_IMAGE,
+    scope: MediaAssetScope.PUBLIC,
+    artistId: groupId ?? artistId ?? undefined,
+    postIdOrTemp: "new",
+    attachmentCountInPost: mediaAssetIds.length + 1,
+  };
+  const { upload } = useMediaUpload(presignItem);
+
+  const handleImageChange = async (e) => {
     const file = e.target.files?.[0];
-    if (!file) return;
-    if (!file.type.startsWith("image/")) return;
-    setImageFile(file);
-    setImagePreview(URL.createObjectURL(file));
+    if (!file || !file.type.startsWith("image/") || !upload) return;
+    const result = await upload(file);
+    if (result?.mediaAssetId && result?.url) {
+      setMediaAssetIds((prev) => [...prev, result.mediaAssetId]);
+      setAttachmentPreviews((prev) => [...prev, { mediaAssetId: result.mediaAssetId, url: result.url }]);
+    }
+    e.target.value = "";
   };
 
-  const removeImage = () => {
-    if (imagePreview) URL.revokeObjectURL(imagePreview);
-    setImageFile(null);
-    setImagePreview(null);
+  const removeImage = (mediaAssetId) => {
+    setMediaAssetIds((prev) => prev.filter((id) => id !== mediaAssetId));
+    setAttachmentPreviews((prev) => prev.filter((p) => p.mediaAssetId !== mediaAssetId));
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!content.trim()) return;
-    router.push(artistId ? "/posts" : "/home");
+    if (!artistId && !groupId) {
+      router.push("/home");
+      return;
+    }
+    setSubmitLoading(true);
+    try {
+      await request("/api/artist-posts", {
+        method: "POST",
+        body: {
+          groupId: groupId ?? artistId,
+          title: "",
+          content: content.trim(),
+          isMembershipOnly: false,
+          isNotice: false,
+          mediaAssetIds,
+        },
+      });
+      router.push("/posts");
+    } catch (err) {
+      console.error(err);
+      alert(err?.data?.message ?? err?.message ?? "게시에 실패했습니다.");
+    } finally {
+      setSubmitLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -54,9 +91,10 @@ export default function NewPostPage() {
       .then((res) => {
         const p = res.data?.profile;
         if (p?.id != null) setArtistId(p.id);
+        if (p?.groupId != null) setGroupId(p.groupId);
         setProfile(p ?? null);
       })
-      .catch(() => { setArtistId(null); setProfile(null); });
+      .catch(() => { setArtistId(null); setGroupId(null); setProfile(null); });
   }, []);
 
   return (
@@ -88,24 +126,33 @@ export default function NewPostPage() {
           <div className="mt-6">
             <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">사진 첨부</span>
             <input ref={fileInputRef} type="file" accept="image/*" onChange={handleImageChange} className="hidden" />
-            {!imagePreview ? (
+            {attachmentPreviews.length > 0 ? (
+              <div className="space-y-3">
+                {attachmentPreviews.map((p) => (
+                  <div key={p.mediaAssetId} className="relative rounded-2xl overflow-hidden border border-white/[0.08]">
+                    <img src={p.url} alt="미리보기" className="w-full max-h-80 object-contain bg-black/20" />
+                    <button type="button" onClick={() => removeImage(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
+                      <span className="material-symbols-outlined text-lg">close</span>
+                    </button>
+                  </div>
+                ))}
+                <button type="button" onClick={() => fileInputRef.current?.click()} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm">
+                  + 추가
+                </button>
+              </div>
+            ) : (
               <button type="button" onClick={() => fileInputRef.current?.click()} className="w-full py-8 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2">
                 <span className="material-symbols-outlined text-4xl">add_photo_alternate</span>
                 <span className="text-sm font-bold">클릭하여 사진 추가</span>
               </button>
-            ) : (
-              <div className="relative rounded-2xl overflow-hidden border border-white/[0.08]">
-                <img src={imagePreview} alt="미리보기" className="w-full max-h-80 object-contain bg-black/20" />
-                <button type="button" onClick={removeImage} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
-                  <span className="material-symbols-outlined text-lg">close</span>
-                </button>
-              </div>
             )}
           </div>
         </Surface>
         <div className="flex gap-3 justify-end">
           <Button variant="ghost" href="/posts">취소</Button>
-          <Button type="submit" variant="primary" className="px-8 py-3">게시하기</Button>
+          <Button type="submit" variant="primary" className="px-8 py-3" disabled={submitLoading}>
+            {submitLoading ? "게시 중..." : "게시하기"}
+          </Button>
         </div>
       </form>
     </div>

--- a/frontend/lib/replayApi.js
+++ b/frontend/lib/replayApi.js
@@ -5,6 +5,10 @@ import { BASE_URL, normalizeToken, request } from "@/lib/api";
 
 export const ReplayAccessType = { FREE: "FREE", PAID: "PAID" };
 
+export function listByArtist(artistId) {
+  return request("/api/replays", { query: { artistId } });
+}
+
 export function getCandidates(artistId) {
   return request("/api/replays/candidates", { query: { artistId } });
 }


### PR DESCRIPTION
1. Replay 목록 API + thumbnailUrl (백엔드)
ReplayController: GET /api/replays?artistId=xxx 추가
ReplayQueryService: listByArtist(), toReplayResponse(), buildThumbnailUrl() 추가
ReplayResponse: thumbnailUrl 필드 추가
SecurityConfig: Replay 목록·단건 조회 permitAll 설정

2. 다시보기 목록 실제 연동 (프론트)
replayApi.js: listByArtist(artistId) 추가
artists/[id]/page.js: MOCK 제거, listReplays()로 VOD 목록 로드, vodList를 실제 API 데이터로 교체

3. MV 탭 라벨 + artist-console MV 네비
artists/[id]: 탭 라벨 "MV." → "MV"
artist-console/page.js: 탭에 MV 링크 추가 (href: /artist-console/music-videos)
ArtistConsoleGuard: GROUP_MEMBER_ALLOWED에 /artist-console/music-videos 추가

4. music-videos artistId 자동화
music-videos/page.js: /api/artist/mypage로 artistId 조회, DEFAULT_ARTIST_ID 제거

5. 프로필/커버 이미지 파일 업로드
백엔드
ArtistProfileUpdateRequest: profileImageMediaAssetId, bannerImageMediaAssetId 추가
ArtistService: MediaAsset → URL 변환 로직 추가
MediaAssetService: getPublicUrlForArtistProfileImage(), getPublicUrlForArtistCover() 추가
프론트 (mypage): 아티스트 프로필 수정에 파일 업로드 UI 추가 (프로필·배너 모두)

6. 게시물 첨부파일
posts/new/page.js: useMediaUpload + mediaAssetIds로 presign 업로드 후 POST /api/artist-posts 호출
artist-console/page.js: 새 글 작성 모달에 첨부파일 업로드 연결

7. 다시보기 발행 썸네일
백엔드
ReplayPublishRequest: thumbnailMediaAssetId 추가
ReplayCommandService: thumbnailMediaAssetId 처리 후 updateThumbnailKey() 호출
프론트 (artist-console/live): 발행 폼에 썸네일 업로드 UI 추가