### PR TITLE
fix: 프론트 코드 리펙토링

### DIFF
--- a/backend/src/main/java/org/example/backend/media_asset/service/S3MediaClient.java
+++ b/backend/src/main/java/org/example/backend/media_asset/service/S3MediaClient.java
@@ -27,12 +27,13 @@ public class S3MediaClient {
     private final S3Presigner s3Presigner;
     private final AwsProperties awsProperties;
 
-    // S3에 대한 presigned PUT URL과 필수 헤더를 생성한다.
+    // S3에 대한 presigned PUT URL을 생성한다.
+    // Content-Type을 서명에 넣지 않아, 클라이언트가 보내는 Content-Type과 불일치로 403이 나지 않도록 함.
+    // 클라이언트는 응답의 requiredHeaders(Content-Type)를 PUT 요청에 넣어 객체 메타데이터를 설정할 수 있다.
     public PresignedUpload presignPut(String objectKey, String contentType, Duration duration) {
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(awsProperties.getS3().getBucketName())
                 .key(objectKey)
-                .contentType(contentType)
                 .build();
 
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()

--- a/docs/FRONTEND_MEDIA_AUDIT.md
+++ b/docs/FRONTEND_MEDIA_AUDIT.md
@@ -1,0 +1,171 @@
+# 프론트엔드 미디어·첨부·프로필·뮤비·다시보기 정밀 검사 보고서
+
+첨부파일, 커버이미지, 프로필이미지, 뮤직비디오, 다시보기 및 게시물 연관 코드를 검사한 결과와 개선 제안.
+
+---
+
+## 1. 요약
+
+| 영역 | 상태 | 이슈 |
+|------|------|------|
+| 게시물 첨부 | 중복 다수 | 3곳에서 거의 동일한 presignItem + uploadFile + state 로직 반복 |
+| 프로필/커버 이미지 | 산재 | mypage 한 파일 내 상태·핸들러 과다, useMediaUpload 2개 혼용 |
+| 뮤직비디오 | 일부 정리됨 | YouTube watch URL 유틸 공통화 완료, 링크는 일관 적용 권장 |
+| 다시보기 | 양호 | replayApi + useMediaUpload 사용, live 페이지만 복잡 |
+| 공통 | 하드코딩 | 5개, 600초, "tmp_new" 등 상수 분산 |
+
+---
+
+## 2. 게시물 첨부 (Post Attachments)
+
+### 2.1 연관 파일
+
+- `app/posts/new/page.js` — 새 글 작성
+- `app/posts/[id]/edit/page.js` — 글 수정 (팬/아티스트 공통)
+- `app/artist-console/posts/[id]/edit/page.js` — 아티스트 콘솔 글 수정
+- `lib/mediaAssetApi.js` — presign, complete, uploadFile
+- `lib/usePostAttachments.js` — **신규** 공통 훅 (도입 시 중복 제거용)
+
+### 2.2 발견 이슈
+
+1. **동일 로직 3중 복제**
+   - 세 페이지 모두 `mediaAssetIds`, `attachmentPreviews` state
+   - `presignItem` 구성이 거의 동일: `category`(POST_IMAGE/POST_VIDEO), `scope`, `artistId`, `postIdOrTemp`, `attachmentCountInPost`, (영상 시) `durationSecondsRequested: 600`
+   - `uploadFile` 호출 후 `setMediaAssetIds` / `setAttachmentPreviews` 처리 반복
+   - `removeAttachment` 로직 동일
+
+2. **하드코딩**
+   - 최대 개수 `5` → `lib/mediaAssetApi.js`에 `MAX_POST_ATTACHMENTS = 5` 추가됨
+   - 영상 길이 `600` → `POST_VIDEO_DURATION_SECONDS = 600` 추가됨
+   - `postIdOrTemp`: `"tmp_new"`, `"tmp_edit"` 문자열 각 페이지에 직접 기입
+
+3. **일관성**
+   - new: `artistId: postGroupIdNum` (숫자 강제)
+   - edit 두 곳: `artistId: postGroupId` (숫자 미변환 가능성)
+   - 수정 페이지는 기존 첨부 로드 시 `attachments` → `mediaAssetIds`/`attachmentPreviews` 초기화 방식만 약간 상이
+
+### 2.3 개선 제안
+
+- **즉시 적용 가능**: `posts/new`, 두 edit 페이지에서 `MAX_POST_ATTACHMENTS`, `POST_VIDEO_DURATION_SECONDS`를 `@/lib/mediaAssetApi`에서 import 해 사용.
+- **점진 적용**: `usePostAttachments` 훅을 한 페이지씩 적용해 state + add/remove + presignItem 구성 통합.
+
+---
+
+## 3. 프로필 이미지 · 커버(배너) 이미지
+
+### 3.1 연관 파일
+
+- `app/mypage/page.js` — 팬 프로필 이미지, 아티스트 프로필/배너
+- `lib/useMediaUpload.js` — uploadFile 래퍼
+- `lib/mediaAssetApi.js` — PROFILE_IMAGE, ARTIST_COVER_IMAGE
+
+### 3.2 발견 이슈
+
+1. **mypage 단일 파일 과다 책임**
+   - 팬: 프로필 이미지 변경 (파일만, URL 입력 제거됨)
+   - 아티스트: 프로필 수정 모달(소개, 프로필 이미지, 배너) — 파일 업로드 + URL 입력 혼합
+   - 상태: `profileImageMediaAssetId`, `profileImagePreviewUrl`, `artistProfileEdit`(bio, profileImageUrl, bannerImageUrl, 각 MediaAssetId/PreviewUrl) 등 한 페이지에 집중
+
+2. **useMediaUpload 2회 사용**
+   - `profilePresignItem` (PROFILE_IMAGE, PUBLIC) → `uploadProfileImage`
+   - `coverPresignItem` (ARTIST_COVER_IMAGE, PUBLIC, artistId) → `uploadCoverImage`
+   - presignItem 객체가 매 렌더마다 새로 생성되나, 훅 내부에서 uploadFile만 쓰므로 실사용에는 문제 없음.
+
+3. **UI 패턴 반복**
+   - "파일 업로드" 버튼 + hidden input + 미리보기 + 제거 버튼
+   - 아티스트 모달: 프로필 이미지 블록과 배너 블록이 거의 동일한 구조
+
+### 3.3 개선 제안
+
+- **공통 컴포넌트**: `FileUploadWithPreview({ accept, onUpload, previewUrl, onRemove, disabled, label })` 형태로 한 번만 구현 후, 프로필/배너/게시물 첨부 등에서 재사용 검토.
+- **mypage 분리**: "프로필 이미지 변경" 모달을 `components/mypage/ProfileImageEditModal.jsx` 등으로 분리하면 가독성·테스트에 유리.
+
+---
+
+## 4. 뮤직비디오 (MV)
+
+### 4.1 연관 파일
+
+- `app/artists/[id]/page.js` — 아티스트 페이지 MV 탭 (목록, 링크)
+- `app/artist-console/music-videos/page.js` — MV 관리(등록/삭제), "보기" 링크
+- `lib/musicVideoApi.js` — list, create, remove
+- `lib/youtubeUtils.js` — **신규** `toYouTubeWatchUrl` (embed/short → watch URL)
+
+### 4.2 발견 이슈
+
+1. **YouTube 링크**
+   - 아티스트 페이지: `toYouTubeWatchUrl(mv.embedUrl) || mv.embedUrl` 사용 (watch URL로 통일)
+   - 아티스트 콘솔 MV 관리: "보기" 링크를 `toYouTubeWatchUrl(v.embedUrl) || v.embedUrl`로 통일해 두면 153 등 오류 방지에 일관됨.
+
+2. **API 사용**
+   - `musicVideoApi`는 단순 CRUD, 다른 미디어(업로드)와 달리 presign 없음. 구조는 명확함.
+
+### 4.3 개선 제안
+
+- `toYouTubeWatchUrl`을 `lib/youtubeUtils.js`에서 export하고, MV 링크가 열리는 모든 곳에서 사용 (적용 완료).
+
+---
+
+## 5. 다시보기 (Replay)
+
+### 5.1 연관 파일
+
+- `app/artist-console/live/page.js` — 다시보기 발행, 수동 업로드(REPLAY_VIDEO presign)
+- `app/replay/[replayId]/page.js` — 다시보기 시청
+- `app/artists/[id]/page.js` — 아티스트 페이지 VOD 탭
+- `lib/replayApi.js` — 목록, publish, createManualReplay, publishManualReplay, getReplay, access
+
+### 5.2 발견 이슈
+
+1. **live 페이지 복잡도**
+   - 라이브 세션 로드, 다시보기 후보 목록, 발행 폼, 수동 업로드(슬롯 생성 → presign → upload → complete → publish)가 한 페이지에 있음.
+   - `manualVideoPresignItem`이 `manualReplay?.replayId` 유무에 따라 바뀌고, fallback으로 `replayIdOrTemp: "tmp_manual"` 사용.
+
+2. **일관성**
+   - 다시보기 썸네일 업로드는 `useMediaUpload(thumbnailPresignItem)` 사용. REPLAY_VIDEO는 `uploadFile` 호출을 훅으로 감싼 패턴으로, 게시물 첨부와 비슷한 “업로드 한 번에 처리” 구조.
+
+### 5.3 개선 제안
+
+- live 페이지는 "다시보기 발행" / "수동 업로드"를 별도 컴포넌트나 섹션 파일로 나누면 가독성 향상.
+- `replayIdOrTemp: "tmp_manual"` 등 문자열 상수를 `lib/mediaAssetApi.js` 또는 `lib/replayApi.js` 주석/상수로 정리 권장.
+
+---
+
+## 6. 기타 연관 코드
+
+### 6.1 getAuthHeaders / BASE_URL
+
+- `getAuthHeaders()`가 여러 페이지에 동일하게 정의됨 (posts/new, posts/[id]/edit, mypage, artists/[id] 등).
+- **제안**: `lib/api.js`에 `getAuthHeaders()`를 두고, 필요한 페이지에서 import 해 사용.
+
+### 6.2 아바타/프로필 이미지 fallback
+
+- `getDefaultAvatarUrl(nickname)` 사용처 다수.
+- 일부: `profile?.profileImageUrl || \`https://picsum.photos/seed/...\`` 등 URL 하드코딩.
+- **제안**: 아바타 노출은 가능한 한 `getDefaultAvatarUrl`로 통일하고, picsum 등은 공통 상수나 유틸 하나로 모음.
+
+### 6.3 게시물 목록/상세의 첨부 표시
+
+- `attachments?.[0]?.url`로 대표 이미지 사용하는 패턴이 여러 곳에 반복 (home, posts, artist-console, artists/[id] 등).
+- **제안**: `getPostRepresentativeImage(post)` 같은 작은 유틸로 한 곳에 모아 두고 재사용.
+
+---
+
+## 7. 적용된 변경 사항 (이번 정밀 검사 반영)
+
+- `lib/mediaAssetApi.js`: `MAX_POST_ATTACHMENTS`, `POST_VIDEO_DURATION_SECONDS` 상수 추가.
+- `lib/youtubeUtils.js`: `toYouTubeWatchUrl` 생성, 아티스트 페이지·아티스트 콘솔 MV에서 import 해 사용.
+- `lib/usePostAttachments.js`: 게시물 첨부 state + add/remove + presignItem 구성 공통 훅 추가 (선택 도입용).
+- `app/artist-console/music-videos/page.js`: "보기" 링크에 `toYouTubeWatchUrl` 적용.
+
+---
+
+## 8. 권장 작업 순서
+
+1. **단기**: 게시물 3페이지에서 `MAX_POST_ATTACHMENTS`, `POST_VIDEO_DURATION_SECONDS` import 후 하드코딩 제거.
+2. **단기**: `getAuthHeaders`를 `lib/api.js`로 올려서 중복 제거.
+3. **중기**: 한 페이지씩 `usePostAttachments` 도입해 게시물 첨부 로직 통합.
+4. **중기**: 프로필/배너용 `FileUploadWithPreview` 공통 컴포넌트 추출 및 mypage 리팩터.
+5. **장기**: artist-console/live 페이지를 "발행" / "수동 업로드" 등 역할별로 분리.
+
+이 문서는 첨부파일·커버·프로필·뮤비·다시보기 및 게시물 연관 코드에 대한 정밀 검사 결과와, 스파게티/하드코딩 완화를 위한 제안을 담고 있음.

--- a/frontend/app/artist-console/music-videos/page.js
+++ b/frontend/app/artist-console/music-videos/page.js
@@ -7,6 +7,7 @@ import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
 import { list, create, remove } from "@/lib/musicVideoApi";
 import { request } from "@/lib/api";
+import { toYouTubeWatchUrl } from "@/lib/youtubeUtils";
 
 export default function ArtistMusicVideosPage() {
   const [artistId, setArtistId] = useState(null);
@@ -180,7 +181,7 @@ export default function ArtistMusicVideosPage() {
                 </div>
                 <div className="flex gap-2">
                   <a
-                    href={v.embedUrl}
+                    href={toYouTubeWatchUrl(v.embedUrl) || v.embedUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="px-3 py-2 bg-white/10 text-white rounded-lg text-sm hover:bg-white/20"

--- a/frontend/app/artist-console/posts/[id]/edit/page.js
+++ b/frontend/app/artist-console/posts/[id]/edit/page.js
@@ -6,7 +6,8 @@ import { request } from "@/lib/api";
 import Surface from "@/components/ui/Surface";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
-import { uploadFile, MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
+import { usePostAttachments } from "@/lib/usePostAttachments";
+import { MAX_POST_ATTACHMENTS } from "@/lib/mediaAssetApi";
 
 function EditPostContent() {
   const router = useRouter();
@@ -18,11 +19,7 @@ function EditPostContent() {
   const [content, setContent] = useState("");
   const [isMembershipOnly, setIsMembershipOnly] = useState(false);
   const [isNotice, setIsNotice] = useState(false);
-  const [mediaAssetIds, setMediaAssetIds] = useState([]);
-  const [attachmentPreviews, setAttachmentPreviews] = useState([]);
-  const [imagePreview, setImagePreview] = useState(null);
-  const [imageFile, setImageFile] = useState(null);
-  const [initialImageUrl, setInitialImageUrl] = useState(null);
+  const [canSetNotice, setCanSetNotice] = useState(false);
   const [writerNickname, setWriterNickname] = useState("");
   const [writerAvatar, setWriterAvatar] = useState("");
   const [loading, setLoading] = useState(true);
@@ -32,7 +29,11 @@ function EditPostContent() {
   const fileInputRef = useRef(null);
 
   const postGroupId = groupId;
-  const canAddAttachment = !!postGroupId && mediaAssetIds.length < 5;
+  const attachments = usePostAttachments({
+    postGroupId,
+    postIdOrTemp: numericId,
+    initialAttachments: [],
+  });
 
   // 기존 게시물 로드
   useEffect(() => {
@@ -48,13 +49,11 @@ function EditPostContent() {
         setIsNotice(!!data.isNotice);
         setWriterNickname(data.writerNickname || "");
         setWriterAvatar(data.writerProfileImageUrl || "");
-        const atts = data.attachments || [];
-        setMediaAssetIds(atts.map((a) => a.mediaAssetId).filter(Boolean));
-        setAttachmentPreviews(atts.map((a) => ({ mediaAssetId: a.mediaAssetId, url: a.url, isVideo: a.contentType?.startsWith?.("video/") })));
+        attachments.setAttachmentsFromApi(data.attachments || []);
+        setCanSetNotice(!!data.canSetNotice);
       })
       .catch(() => setNotFound(true))
       .finally(() => setLoading(false));
-  const [canSetNotice, setCanSetNotice] = useState(false);
   }, [numericId]);
 
   // 개인 아티스트 여부 (공지 토글 노출용)
@@ -72,42 +71,10 @@ function EditPostContent() {
     request("/api/user/profile").then((d) => setGroupId(d?.groupId ?? d?.id ?? null)).catch(() => {});
   }, []);
 
-  const handleAttachmentChange = async (e) => {
+  const handleAttachmentChange = (e) => {
     const file = e.target.files?.[0];
-    if (!file || !postGroupId || mediaAssetIds.length >= 5) {
-      e.target.value = "";
-      return;
-    }
-    const isImage = file.type.startsWith("image/");
-    const isVideo = file.type.startsWith("video/");
-    if (!isImage && !isVideo) {
-      e.target.value = "";
-      return;
-    }
-    try {
-      const presignItem = {
-        category: isVideo ? MediaAssetCategory.POST_VIDEO : MediaAssetCategory.POST_IMAGE,
-        scope: MediaAssetScope.PUBLIC,
-        artistId: postGroupId,
-        postIdOrTemp: (numericId > 0 && !isNaN(numericId)) ? String(numericId) : "tmp_edit",
-        attachmentCountInPost: mediaAssetIds.length + 1,
-      };
-      if (isVideo) presignItem.durationSecondsRequested = 600;
-      const result = await uploadFile(file, presignItem);
-      if (result?.status === "READY" && result?.mediaAssetId && result?.url) {
-        setMediaAssetIds((prev) => [...prev, result.mediaAssetId]);
-        setAttachmentPreviews((prev) => [...prev, { mediaAssetId: result.mediaAssetId, url: result.url, isVideo }]);
-      }
-    } catch (err) {
-      console.error("업로드 실패", err);
-      alert(err?.data?.message || err?.message || "업로드에 실패했습니다.");
-    }
     e.target.value = "";
-  };
-
-  const removeAttachment = (mediaAssetId) => {
-    setMediaAssetIds((prev) => prev.filter((id) => id !== mediaAssetId));
-    setAttachmentPreviews((prev) => prev.filter((p) => p.mediaAssetId !== mediaAssetId));
+    if (file) attachments.addAttachment(file);
   };
 
   const handleSubmit = async (e) => {
@@ -122,8 +89,8 @@ function EditPostContent() {
           content: content.trim(),
           isMembershipOnly,
           isNotice,
-          mediaAssetIds,
-          representativeMediaAssetId: mediaAssetIds[0] ?? null,
+          mediaAssetIds: attachments.mediaAssetIds,
+          representativeMediaAssetId: attachments.representativeMediaAssetId,
         },
       });
       router.push("/artist-console/posts");
@@ -253,31 +220,34 @@ function EditPostContent() {
           {/* 첨부 (최대 5개, 미리보기 첫 장으로 목록 노출) */}
           <div className="mt-6">
             <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">
-              첨부 (이미지·영상 최대 5개, 목록 미리보기 첫 장)
+              첨부 (이미지·영상 최대 {MAX_POST_ATTACHMENTS}개, 목록 미리보기 첫 장)
             </span>
+            {attachments.uploadError && (
+              <p className="text-red-400 text-sm mb-2">{attachments.uploadError}</p>
+            )}
             <input ref={fileInputRef} type="file" accept="image/*,video/*" onChange={handleAttachmentChange} className="hidden" />
-            {attachmentPreviews.length > 0 ? (
+            {attachments.attachmentPreviews.length > 0 ? (
               <div className="space-y-3">
-                {attachmentPreviews.map((p) => (
+                {attachments.attachmentPreviews.map((p) => (
                   <div key={p.mediaAssetId} className="relative rounded-2xl overflow-hidden border border-white/[0.08]">
                     {p.isVideo ? (
                       <video src={p.url} controls className="w-full max-h-80 object-contain bg-black/20" />
                     ) : (
                       <img src={p.url} alt="미리보기" className="w-full max-h-80 object-contain bg-black/20" />
                     )}
-                    <button type="button" onClick={() => removeAttachment(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
+                    <button type="button" onClick={() => attachments.removeAttachment(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
                       <span className="material-symbols-outlined text-lg">close</span>
                     </button>
                   </div>
                 ))}
-                {canAddAttachment && (
+                {attachments.canAddAttachment && (
                   <button type="button" onClick={() => fileInputRef.current?.click()} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm">+ 추가</button>
                 )}
               </div>
             ) : (
-              <button type="button" onClick={() => canAddAttachment && fileInputRef.current?.click()} disabled={!canAddAttachment} className="w-full py-8 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2 disabled:opacity-50">
+              <button type="button" onClick={() => attachments.canAddAttachment && fileInputRef.current?.click()} disabled={!attachments.canAddAttachment} className="w-full py-8 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2 disabled:opacity-50">
                 <span className="material-symbols-outlined text-4xl">add_photo_alternate</span>
-                <span className="text-sm font-bold">{!postGroupId ? "프로필 로딩 중…" : "이미지 또는 영상 추가 (최대 5개)"}</span>
+                <span className="text-sm font-bold">{!postGroupId ? "프로필 로딩 중…" : "이미지 또는 영상 추가 (최대 " + MAX_POST_ATTACHMENTS + "개)"}</span>
               </button>
             )}
           </div>

--- a/frontend/app/artists/[id]/page.js
+++ b/frontend/app/artists/[id]/page.js
@@ -9,7 +9,7 @@ import axios from "axios";
 import { MOCK_ARTISTS, MOCK_POSTS } from "@/lib/mockData";
 import { list as listMusicVideos } from "@/lib/musicVideoApi";
 import { listByArtist as listReplays } from "@/lib/replayApi";
-import { request, apiGet, apiPost, BASE_URL } from "@/lib/api";
+import { request, apiGet, apiPost, BASE_URL, getAuthHeaders } from "@/lib/api";
 import {
     isUpcoming,
     concertIncludesArtist,
@@ -17,6 +17,7 @@ import {
     getArtistNamesArray,
     formatDateShort
 } from "@/lib/concertUtils";
+import { toYouTubeWatchUrl } from "@/lib/youtubeUtils";
 
 // 컴포넌트
 import Surface from "@/components/ui/Surface";
@@ -26,27 +27,7 @@ import MembershipOnlyModal from "@/components/common/MembershipOnlyModal";
 
 // --- 상수 및 헬퍼 함수 ---
 const CANDY_COST = 500;
-
-/** embed URL(또는 short URL)을 YouTube watch URL로 변환. 새 탭에서 열 때 153 오류 방지 */
-function toYouTubeWatchUrl(url) {
-  if (!url || typeof url !== "string") return null;
-  const trimmed = url.trim();
-  const embedMatch = trimmed.match(/youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/i);
-  if (embedMatch) return `https://www.youtube.com/watch?v=${embedMatch[1]}`;
-  const shortMatch = trimmed.match(/youtu\.be\/([a-zA-Z0-9_-]{11})/i);
-  if (shortMatch) return `https://www.youtube.com/watch?v=${shortMatch[1]}`;
-  if (/youtube\.com\/watch\?/i.test(trimmed)) return trimmed;
-  return null;
-}
 const FAN_PROFILES_API = `${BASE_URL}/api/fan-profiles`;
-
-function getAuthHeaders() {
-    const token = typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
-    return {
-        "Content-Type": "application/json",
-        ...(token && { Authorization: token }),
-    };
-}
 
 function getCurrentUser() {
     if (typeof window === "undefined") return null;

--- a/frontend/app/mypage/page.js
+++ b/frontend/app/mypage/page.js
@@ -9,16 +9,9 @@ import Button from "@/components/ui/Button";
 import SectionTitle from "@/components/ui/SectionTitle";
 import { getDefaultAvatarUrl } from "@/lib/avatar";
 import { redirectToGuestHome } from "@/lib/authRedirect";
-import { BASE_URL, request } from "@/lib/api";
+import { BASE_URL, request, getAuthHeaders } from "@/lib/api";
 import { useMediaUpload } from "@/lib/useMediaUpload";
 import { MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
-
-function getAuthHeaders() {
-  if (typeof window === "undefined") return {};
-  const token = localStorage.getItem("accessToken");
-  const pure = token?.replace(/^Bearer\s+/i, "").trim();
-  return pure ? { Authorization: `Bearer ${pure}` } : {};
-}
 
 /** JWT payload에서 관리자 여부 판단 (API 호출 없이, 403 방지) */
 function getIsAdminFromToken() {

--- a/frontend/app/posts/[id]/edit/page.js
+++ b/frontend/app/posts/[id]/edit/page.js
@@ -1,22 +1,15 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
-import Link from "next/link";
 import { useRouter, useParams } from "next/navigation";
 import axios from "axios";
 import Surface from "@/components/ui/Surface";
 import { getDefaultAvatarUrl } from "@/lib/avatar";
-import { BASE_URL, request } from "@/lib/api";
+import { BASE_URL, request, getAuthHeaders } from "@/lib/api";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
-import { uploadFile, MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
-
-function getAuthHeaders() {
-  if (typeof window === "undefined") return {};
-  const token = localStorage.getItem("accessToken");
-  const pure = token?.replace(/^Bearer\s+/i, "").trim();
-  return pure ? { Authorization: `Bearer ${pure}` } : {};
-}
+import { usePostAttachments } from "@/lib/usePostAttachments";
+import { MAX_POST_ATTACHMENTS } from "@/lib/mediaAssetApi";
 
 export default function EditPostPage() {
   const router = useRouter();
@@ -27,15 +20,16 @@ export default function EditPostPage() {
   const [post, setPost] = useState(null);
   const [postLoaded, setPostLoaded] = useState(false);
   const [content, setContent] = useState("");
-  const [mediaAssetIds, setMediaAssetIds] = useState([]);
-  const [attachmentPreviews, setAttachmentPreviews] = useState([]);
   const [groupId, setGroupId] = useState(null);
   const [submitLoading, setSubmitLoading] = useState(false);
-  const [canSetNotice, setCanSetNotice] = useState(false);
   const fileInputRef = useRef(null);
 
   const postGroupId = groupId ?? artistId;
-  const canAddAttachment = !!postGroupId && mediaAssetIds.length < 5;
+  const attachments = usePostAttachments({
+    postGroupId,
+    postIdOrTemp: id,
+    initialAttachments: [],
+  });
 
   useEffect(() => {
     if (!id) return;
@@ -44,50 +38,16 @@ export default function EditPostPage() {
       .then((data) => {
         setPost(data);
         setContent(data?.content ?? "");
-        const atts = data?.attachments ?? [];
-        setMediaAssetIds(atts.map((a) => a.mediaAssetId).filter(Boolean));
-        setAttachmentPreviews(atts.map((a) => ({ mediaAssetId: a.mediaAssetId, url: a.url, isVideo: a.contentType?.startsWith?.("video/") })));
+        attachments.setAttachmentsFromApi(data?.attachments ?? []);
       })
       .catch(() => setPost(null))
       .finally(() => setPostLoaded(true));
   }, [id]);
 
-  const handleAttachmentChange = async (e) => {
+  const handleAttachmentChange = (e) => {
     const file = e.target.files?.[0];
-    if (!file || !postGroupId || mediaAssetIds.length >= 5) {
-      e.target.value = "";
-      return;
-    }
-    const isImage = file.type.startsWith("image/");
-    const isVideo = file.type.startsWith("video/");
-    if (!isImage && !isVideo) {
-      e.target.value = "";
-      return;
-    }
-    try {
-      const presignItem = {
-        category: isVideo ? MediaAssetCategory.POST_VIDEO : MediaAssetCategory.POST_IMAGE,
-        scope: MediaAssetScope.PUBLIC,
-        artistId: postGroupId,
-        postIdOrTemp: (id && String(id).trim() !== "") ? String(id) : "tmp_edit",
-        attachmentCountInPost: mediaAssetIds.length + 1,
-      };
-      if (isVideo) presignItem.durationSecondsRequested = 600;
-      const result = await uploadFile(file, presignItem);
-      if (result?.status === "READY" && result?.mediaAssetId && result?.url) {
-        setMediaAssetIds((prev) => [...prev, result.mediaAssetId]);
-        setAttachmentPreviews((prev) => [...prev, { mediaAssetId: result.mediaAssetId, url: result.url, isVideo }]);
-      }
-    } catch (err) {
-      console.error(err);
-      alert(err?.data?.message || err?.message || "업로드에 실패했습니다.");
-    }
     e.target.value = "";
-  };
-
-  const removeAttachment = (mediaAssetId) => {
-    setMediaAssetIds((prev) => prev.filter((id) => id !== mediaAssetId));
-    setAttachmentPreviews((prev) => prev.filter((p) => p.mediaAssetId !== mediaAssetId));
+    if (file) attachments.addAttachment(file);
   };
 
   const handleSubmit = async (e) => {
@@ -102,8 +62,8 @@ export default function EditPostPage() {
           content: content.trim(),
           isMembershipOnly: false,
           isNotice: false,
-          mediaAssetIds,
-          representativeMediaAssetId: mediaAssetIds[0] ?? null,
+          mediaAssetIds: attachments.mediaAssetIds,
+          representativeMediaAssetId: attachments.representativeMediaAssetId,
         },
       });
       router.push(artistId ? "/posts" : "/home");
@@ -183,30 +143,30 @@ export default function EditPostPage() {
           </label>
 
           <div className="mt-6">
-            <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">첨부 (이미지·영상 최대 5개, 목록 미리보기 첫 장)</span>
+            <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">첨부 (이미지·영상 최대 {MAX_POST_ATTACHMENTS}개, 목록 미리보기 첫 장)</span>
             <input ref={fileInputRef} type="file" accept="image/*,video/*" onChange={handleAttachmentChange} className="hidden" />
-            {attachmentPreviews.length > 0 ? (
+            {attachments.attachmentPreviews.length > 0 ? (
               <div className="space-y-3">
-                {attachmentPreviews.map((p) => (
+                {attachments.attachmentPreviews.map((p) => (
                   <div key={p.mediaAssetId} className="relative rounded-2xl overflow-hidden border border-white/[0.08]">
                     {p.isVideo ? (
                       <video src={p.url} controls className="w-full max-h-80 object-contain bg-black/20" />
                     ) : (
                       <img src={p.url} alt="미리보기" className="w-full max-h-80 object-contain bg-black/20" />
                     )}
-                    <button type="button" onClick={() => removeAttachment(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
+                    <button type="button" onClick={() => attachments.removeAttachment(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
                       <span className="material-symbols-outlined text-lg">close</span>
                     </button>
                   </div>
                 ))}
-                {canAddAttachment && (
+                {attachments.canAddAttachment && (
                   <button type="button" onClick={() => fileInputRef.current?.click()} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm">+ 추가</button>
                 )}
               </div>
             ) : (
-              <button type="button" onClick={() => canAddAttachment && fileInputRef.current?.click()} disabled={!canAddAttachment} className="w-full py-8 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2 disabled:opacity-50">
+              <button type="button" onClick={() => attachments.canAddAttachment && fileInputRef.current?.click()} disabled={!attachments.canAddAttachment} className="w-full py-8 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2 disabled:opacity-50">
                 <span className="material-symbols-outlined text-4xl">add_photo_alternate</span>
-                <span className="text-sm font-bold">{!postGroupId ? "프로필 로딩 중…" : "이미지 또는 영상 추가 (최대 5개)"}</span>
+                <span className="text-sm font-bold">{!postGroupId ? "프로필 로딩 중…" : "이미지 또는 영상 추가 (최대 " + MAX_POST_ATTACHMENTS + "개)"}</span>
               </button>
             )}
           </div>

--- a/frontend/app/posts/new/page.js
+++ b/frontend/app/posts/new/page.js
@@ -7,15 +7,9 @@ import Surface from "@/components/ui/Surface";
 import { getDefaultAvatarUrl } from "@/lib/avatar";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
-import { BASE_URL, request } from "@/lib/api";
-import { uploadFile, MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
-
-function getAuthHeaders() {
-  if (typeof window === "undefined") return {};
-  const token = localStorage.getItem("accessToken");
-  const pure = token?.replace(/^Bearer\s+/i, "").trim();
-  return pure ? { Authorization: `Bearer ${pure}` } : {};
-}
+import { BASE_URL, request, getAuthHeaders } from "@/lib/api";
+import { usePostAttachments } from "@/lib/usePostAttachments";
+import { MAX_POST_ATTACHMENTS } from "@/lib/mediaAssetApi";
 
 export default function NewPostPage() {
   const router = useRouter();
@@ -23,67 +17,34 @@ export default function NewPostPage() {
   const [artistId, setArtistId] = useState(null);
   const [groupId, setGroupId] = useState(null);
   const [content, setContent] = useState("");
-  const [mediaAssetIds, setMediaAssetIds] = useState([]);
-  const [attachmentPreviews, setAttachmentPreviews] = useState([]);
   const [submitLoading, setSubmitLoading] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const [uploadError, setUploadError] = useState("");
+  const [profileError, setProfileError] = useState("");
   const fileInputRef = useRef(null);
 
   const postGroupId = groupId ?? artistId;
-  const canAddAttachment = postGroupId != null && mediaAssetIds.length < 5;
+  const postGroupIdNum = postGroupId != null ? Number(postGroupId) : null;
+  const attachments = usePostAttachments({
+    postGroupId: postGroupIdNum,
+    postIdOrTemp: "tmp_new",
+    initialAttachments: [],
+  });
 
-  const handleAttachmentChange = async (e) => {
+  const handleAttachmentChange = (e) => {
     const file = e.target.files?.[0];
-    if (!file || !postGroupId || mediaAssetIds.length >= 5) {
-      e.target.value = "";
+    e.target.value = "";
+    if (!file) return;
+    if (!attachments.canAddAttachment && profile != null && (postGroupIdNum == null || isNaN(postGroupIdNum))) {
+      attachments.setUploadError("첨부는 아티스트 프로필 로드 후 가능합니다.");
       return;
     }
-    const isImage = file.type.startsWith("image/");
-    const isVideo = file.type.startsWith("video/");
-    if (!isImage && !isVideo) {
-      setUploadError("이미지 또는 영상 파일만 첨부할 수 있습니다.");
-      e.target.value = "";
-      return;
-    }
-    setUploadError("");
-    setUploading(true);
-    try {
-      const presignItem = {
-        category: isVideo ? MediaAssetCategory.POST_VIDEO : MediaAssetCategory.POST_IMAGE,
-        scope: MediaAssetScope.PUBLIC,
-        artistId: postGroupId,
-        postIdOrTemp: "tmp_new",
-        attachmentCountInPost: mediaAssetIds.length + 1,
-      };
-      if (isVideo) presignItem.durationSecondsRequested = 600;
-      const result = await uploadFile(file, presignItem);
-      if (result?.status === "READY" && result?.mediaAssetId && result?.url) {
-        setMediaAssetIds((prev) => [...prev, result.mediaAssetId]);
-        setAttachmentPreviews((prev) => [...prev, { mediaAssetId: result.mediaAssetId, url: result.url, isVideo }]);
-      } else {
-        setUploadError(result?.errorCode || "업로드 검증 실패");
-      }
-    } catch (err) {
-      setUploadError(err?.data?.message || err?.message || "업로드 실패");
-    } finally {
-      setUploading(false);
-      e.target.value = "";
-    }
-  };
-
-  const removeImage = (mediaAssetId) => {
-    setMediaAssetIds((prev) => prev.filter((id) => id !== mediaAssetId));
-    setAttachmentPreviews((prev) => prev.filter((p) => p.mediaAssetId !== mediaAssetId));
-    if (fileInputRef.current) fileInputRef.current.value = "";
+    attachments.addAttachment(file);
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!content.trim()) return;
-    // 게시글 소유 주체 = groupId(그룹/소속 그룹 id) ?? artistId(솔로일 때 본인 id)
-    const postGroupId = groupId ?? artistId;
-    if (!postGroupId) {
+    const gid = groupId ?? artistId;
+    if (!gid) {
       router.push("/home");
       return;
     }
@@ -92,13 +53,13 @@ export default function NewPostPage() {
       await request("/api/artist-posts", {
         method: "POST",
         body: {
-          groupId: postGroupId,
+          groupId: gid,
           title: "",
           content: content.trim(),
           isMembershipOnly: false,
           isNotice: false,
-          mediaAssetIds: mediaAssetIds.length ? mediaAssetIds : null,
-          representativeMediaAssetId: mediaAssetIds[0] ?? null,
+          mediaAssetIds: attachments.mediaAssetIds.length ? attachments.mediaAssetIds : null,
+          representativeMediaAssetId: attachments.representativeMediaAssetId,
         },
       });
       router.push("/posts");
@@ -115,15 +76,20 @@ export default function NewPostPage() {
   useEffect(() => {
     const headers = getAuthHeaders();
     if (!headers.Authorization) return;
+    setProfileError("");
     axios.get(`${BASE_URL}/api/artist/mypage`, { headers })
       .then((res) => {
         const p = res.data?.profile;
         setProfile(p ?? null);
         if (p?.id != null) setArtistId(p.id);
-        // groupId가 있으면 사용, 없으면 id 사용 (솔로 아티스트 또는 구 API 호환)
         setGroupId(p?.groupId ?? p?.id ?? null);
       })
-      .catch(() => { setArtistId(null); setGroupId(null); setProfile(null); });
+      .catch((err) => {
+        setArtistId(null);
+        setGroupId(null);
+        setProfile(null);
+        setProfileError(err?.response?.data?.message || "아티스트 프로필을 불러올 수 없습니다. 새 글 작성은 아티스트 계정에서 가능합니다.");
+      });
   }, []);
 
   return (
@@ -154,33 +120,34 @@ export default function NewPostPage() {
           </label>
           <div className="mt-6">
             <span className="text-[10px] font-black uppercase tracking-widest text-white/55 mb-2 block">첨부 (이미지·영상 최대 5개, 목록 미리보기용 첫 장 표시)</span>
-            {uploadError && <p className="text-red-400 text-xs mb-2">{uploadError}</p>}
+            {profileError && <p className="text-amber-400 text-xs mb-2">{profileError}</p>}
+            {attachments.uploadError && <p className="text-red-400 text-xs mb-2">{attachments.uploadError}</p>}
             <input ref={fileInputRef} type="file" accept="image/*,video/*" onChange={handleAttachmentChange} className="hidden" />
-            {attachmentPreviews.length > 0 ? (
+            {attachments.attachmentPreviews.length > 0 ? (
               <div className="space-y-3">
-                {attachmentPreviews.map((p) => (
+                {attachments.attachmentPreviews.map((p) => (
                   <div key={p.mediaAssetId} className="relative rounded-2xl overflow-hidden border border-white/[0.08]">
                     {p.isVideo ? (
                       <video src={p.url} controls className="w-full max-h-80 object-contain bg-black/20" />
                     ) : (
                       <img src={p.url} alt="미리보기" className="w-full max-h-80 object-contain bg-black/20" />
                     )}
-                    <button type="button" onClick={() => removeImage(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
+                    <button type="button" onClick={() => attachments.removeAttachment(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
                       <span className="material-symbols-outlined text-lg">close</span>
                     </button>
                   </div>
                 ))}
-                {canAddAttachment && (
-                  <button type="button" onClick={() => fileInputRef.current?.click()} disabled={uploading} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm disabled:opacity-50">
-                    {uploading ? "업로드 중..." : "+ 추가"}
+                {attachments.canAddAttachment && (
+                  <button type="button" onClick={() => fileInputRef.current?.click()} disabled={attachments.uploading} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm disabled:opacity-50">
+                    {attachments.uploading ? "업로드 중..." : "+ 추가"}
                   </button>
                 )}
-                {attachmentPreviews.length >= 5 && <p className="text-white/50 text-xs">최대 5개까지 첨부 가능합니다.</p>}
+                {attachments.attachmentPreviews.length >= MAX_POST_ATTACHMENTS && <p className="text-white/50 text-xs">최대 {MAX_POST_ATTACHMENTS}개까지 첨부 가능합니다.</p>}
               </div>
             ) : (
-              <button type="button" onClick={() => canAddAttachment && fileInputRef.current?.click()} disabled={!canAddAttachment || uploading} className="w-full py-8 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2 disabled:opacity-50">
+              <button type="button" onClick={() => attachments.canAddAttachment && fileInputRef.current?.click()} disabled={!attachments.canAddAttachment || attachments.uploading} className="w-full py-8 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center gap-2 disabled:opacity-50">
                 <span className="material-symbols-outlined text-4xl">add_photo_alternate</span>
-                <span className="text-sm font-bold">{!postGroupId ? "프로필 로딩 중…" : "이미지 또는 영상 추가 (최대 5개)"}</span>
+                <span className="text-sm font-bold">{profileError ? "프로필을 불러올 수 없음" : !postGroupIdNum ? "프로필 로딩 중…" : "이미지 또는 영상 추가 (최대 " + MAX_POST_ATTACHMENTS + "개)"}</span>
               </button>
             )}
           </div>

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -43,6 +43,16 @@ export function getToken() {
     return normalizeToken(raw);
 }
 
+/**
+ * axios 등에서 쓸 Authorization 헤더 객체.
+ * 브라우저 외에서는 {} 반환.
+ */
+export function getAuthHeaders() {
+    if (typeof window === "undefined") return {};
+    const token = getToken();
+    return token ? { Authorization: token } : {};
+}
+
 /** refreshToken 조회 (Bearer 제거한 값) */
 function getRefreshTokenRaw() {
     if (typeof window === "undefined") return "";

--- a/frontend/lib/mediaAssetApi.js
+++ b/frontend/lib/mediaAssetApi.js
@@ -24,6 +24,11 @@ export const MediaAssetCategory = {
 
 export const MediaAssetScope = { PUBLIC: "PUBLIC", RESTRICTED: "RESTRICTED" };
 
+/** 게시물 첨부 최대 개수 */
+export const MAX_POST_ATTACHMENTS = 5;
+/** presign 시 영상 최대 길이(초) 요청값 */
+export const POST_VIDEO_DURATION_SECONDS = 600;
+
 export const MediaAssetStatus = {
   INITIATED: "INITIATED",
   READY: "READY",
@@ -77,14 +82,13 @@ export function complete(items) {
  * @returns {Promise<{ mediaAssetId: number; objectKey: string; status: string; url: string | null; errorCode?: string }>}
  */
 export async function uploadFile(file, presignItem) {
+  const rawExt = (file.name.split(".").pop() || "bin").toLowerCase().replace(/[^a-z0-9]/gi, "") || "bin";
+  const contentType = (file.type && file.type.trim()) || (file.name.match(/\.(png|jpe?g|gif|webp)$/i) ? "image/png" : "application/octet-stream");
   const item = {
     ...presignItem,
-    contentType: file.type,
+    contentType,
     sizeBytes: file.size,
-    ext:
-      (file.name.split(".").pop() || "bin")
-        .toLowerCase()
-        .replace(/[^a-z0-9]/gi, "") || "bin",
+    ext: rawExt,
   };
   if (
     file.type.startsWith("video/") &&
@@ -92,20 +96,41 @@ export async function uploadFile(file, presignItem) {
   ) {
     item.durationSecondsRequested = presignItem.durationSecondsRequested;
   }
-  const { items: presignResults } = await presign([item]);
+  let presignResults;
+  try {
+    const res = await presign([item]);
+    presignResults = res.items;
+  } catch (e) {
+    const msg = e?.data?.message || e?.message || "presign 실패";
+    throw new Error(`Presign: ${msg}`);
+  }
+  if (!presignResults?.[0]) throw new Error("Presign 응답이 비어 있습니다.");
   const { objectKey, uploadUrl, requiredHeaders } = presignResults[0];
+  const putHeaders = { ...(requiredHeaders || {}) };
+  if (!putHeaders["Content-Type"] && !putHeaders["content-type"]) {
+    putHeaders["Content-Type"] = contentType;
+  }
 
   const putRes = await fetch(uploadUrl, {
     method: "PUT",
-    headers: requiredHeaders || { "Content-Type": file.type },
+    headers: putHeaders,
     body: file,
   });
   if (!putRes.ok) {
-    throw new Error(`Upload failed: ${putRes.status}`);
+    const text = await putRes.text().catch(() => "");
+    throw new Error(`S3 업로드 실패 (${putRes.status})${text ? `: ${text.slice(0, 80)}` : ""}`);
   }
 
-  const { items: completeResults } = await complete([{ objectKey }]);
-  const result = completeResults[0];
+  let completeResults;
+  try {
+    const res = await complete([{ objectKey }]);
+    completeResults = res.items;
+  } catch (e) {
+    const msg = e?.data?.message || e?.message || "complete 실패";
+    throw new Error(`Complete: ${msg}`);
+  }
+  const result = completeResults?.[0];
+  if (!result) throw new Error("Complete 응답이 비어 있습니다.");
   return {
     mediaAssetId: result.mediaAssetId,
     objectKey: result.objectKey,

--- a/frontend/lib/usePostAttachments.js
+++ b/frontend/lib/usePostAttachments.js
@@ -1,0 +1,109 @@
+/**
+ * 게시물 첨부(이미지·영상 최대 5개) 공통 훅.
+ * presign → S3 PUT → complete 후 mediaAssetIds/attachmentPreviews 유지.
+ * 사용처: posts/new, posts/[id]/edit, artist-console/posts/[id]/edit
+ */
+import { useState, useCallback } from "react";
+import { uploadFile, MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
+import { MAX_POST_ATTACHMENTS, POST_VIDEO_DURATION_SECONDS } from "@/lib/mediaAssetApi";
+
+/**
+ * @param {object} opts
+ * @param {number | string | null} opts.postGroupId - artistId/groupId (presign 필수)
+ * @param {string | number | null} opts.postIdOrTemp - "tmp_new" | "tmp_edit" | 실제 postId
+ * @param {Array<{ mediaAssetId: number; url: string; isVideo?: boolean }>} [opts.initialAttachments] - 수정 시 기존 첨부
+ */
+export function usePostAttachments({ postGroupId, postIdOrTemp, initialAttachments = [] }) {
+  const [mediaAssetIds, setMediaAssetIds] = useState(() =>
+    initialAttachments.map((a) => a.mediaAssetId).filter(Boolean)
+  );
+  const [attachmentPreviews, setAttachmentPreviews] = useState(() =>
+    initialAttachments.map((a) => ({
+      mediaAssetId: a.mediaAssetId,
+      url: a.url,
+      isVideo: a.isVideo,
+    }))
+  );
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState("");
+
+  const groupIdNum = postGroupId != null ? Number(postGroupId) : null;
+  const canAdd = groupIdNum != null && !isNaN(groupIdNum) && mediaAssetIds.length < MAX_POST_ATTACHMENTS;
+
+  const addAttachment = useCallback(
+    async (file) => {
+      if (!file || !canAdd) return;
+      const isImage = file.type.startsWith("image/");
+      const isVideo = file.type.startsWith("video/");
+      if (!isImage && !isVideo) {
+        setUploadError("이미지 또는 영상 파일만 첨부할 수 있습니다.");
+        return;
+      }
+      setUploadError("");
+      setUploading(true);
+      try {
+        const postIdStr =
+          postIdOrTemp != null && String(postIdOrTemp).trim() !== "" && !String(postIdOrTemp).startsWith("tmp_")
+            ? String(postIdOrTemp)
+            : typeof postIdOrTemp === "string"
+              ? postIdOrTemp
+              : "tmp_edit";
+        const presignItem = {
+          category: isVideo ? MediaAssetCategory.POST_VIDEO : MediaAssetCategory.POST_IMAGE,
+          scope: MediaAssetScope.PUBLIC,
+          artistId: groupIdNum,
+          postIdOrTemp: postIdStr,
+          attachmentCountInPost: mediaAssetIds.length + 1,
+        };
+        if (isVideo) presignItem.durationSecondsRequested = POST_VIDEO_DURATION_SECONDS;
+        const result = await uploadFile(file, presignItem);
+        if (result?.status === "READY" && result?.mediaAssetId && result?.url) {
+          setMediaAssetIds((prev) => [...prev, result.mediaAssetId]);
+          setAttachmentPreviews((prev) => [
+            ...prev,
+            { mediaAssetId: result.mediaAssetId, url: result.url, isVideo },
+          ]);
+        } else {
+          setUploadError(result?.errorCode || "업로드 검증 실패");
+        }
+      } catch (err) {
+        const msg = err?.data?.message || err?.message || "업로드 실패";
+        setUploadError(msg);
+        console.error("[게시글 첨부 업로드 실패]", err);
+      } finally {
+        setUploading(false);
+      }
+    },
+    [canAdd, groupIdNum, mediaAssetIds.length, postIdOrTemp]
+  );
+
+  const removeAttachment = useCallback((mediaAssetId) => {
+    setMediaAssetIds((prev) => prev.filter((id) => id !== mediaAssetId));
+    setAttachmentPreviews((prev) => prev.filter((p) => p.mediaAssetId !== mediaAssetId));
+  }, []);
+
+  const setAttachmentsFromApi = useCallback((attachments) => {
+    const list = attachments || [];
+    setMediaAssetIds(list.map((a) => a.mediaAssetId).filter(Boolean));
+    setAttachmentPreviews(
+      list.map((a) => ({
+        mediaAssetId: a.mediaAssetId,
+        url: a.url,
+        isVideo: a.contentType?.startsWith?.("video/"),
+      }))
+    );
+  }, []);
+
+  return {
+    mediaAssetIds,
+    attachmentPreviews,
+    addAttachment,
+    removeAttachment,
+    setAttachmentsFromApi,
+    canAddAttachment: canAdd,
+    uploading,
+    uploadError,
+    setUploadError,
+    representativeMediaAssetId: mediaAssetIds[0] ?? null,
+  };
+}

--- a/frontend/lib/youtubeUtils.js
+++ b/frontend/lib/youtubeUtils.js
@@ -1,0 +1,19 @@
+/**
+ * YouTube URL 유틸.
+ * embed/short URL → watch URL 변환으로 새 탭 열기 시 153 오류 방지.
+ */
+
+/**
+ * @param {string | null | undefined} url
+ * @returns {string | null} watch URL 또는 null
+ */
+export function toYouTubeWatchUrl(url) {
+  if (!url || typeof url !== "string") return null;
+  const trimmed = url.trim();
+  const embedMatch = trimmed.match(/youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/i);
+  if (embedMatch) return `https://www.youtube.com/watch?v=${embedMatch[1]}`;
+  const shortMatch = trimmed.match(/youtu\.be\/([a-zA-Z0-9_-]{11})/i);
+  if (shortMatch) return `https://www.youtube.com/watch?v=${shortMatch[1]}`;
+  if (/youtube\.com\/watch\?/i.test(trimmed)) return trimmed;
+  return null;
+}


### PR DESCRIPTION
usePostAttachments 사용
postGroupId, postIdOrTemp: numericId, initialAttachments: [] 로 훅 사용
게시물 로드 후 attachments.setAttachmentsFromApi(data.attachments || []) 호출
로컬 state/핸들러 제거
mediaAssetIds, attachmentPreviews state 제거
handleAttachmentChange는 attachments.addAttachment(file)만 호출
removeAttachment는 attachments.removeAttachment(mediaAssetId) 사용
제출 시
attachments.mediaAssetIds, attachments.representativeMediaAssetId 사용
UI
attachments.attachmentPreviews, attachments.canAddAttachment, attachments.removeAttachment 사용
최대 개수 문구에 MAX_POST_ATTACHMENTS 사용
attachments.uploadError가 있으면 빨간색 메시지로 표시
import 정리
uploadFile, MediaAssetCategory, MediaAssetScope, POST_VIDEO_DURATION_SECONDS 제거
usePostAttachments, MAX_POST_ATTACHMENTS만 import