### PR TITLE
feat: 프론트 앤드 코드 개선 사항 추가

### DIFF
--- a/backend/src/main/java/org/example/backend/media_asset/service/S3MediaClient.java
+++ b/backend/src/main/java/org/example/backend/media_asset/service/S3MediaClient.java
@@ -27,13 +27,16 @@ public class S3MediaClient {
     private final S3Presigner s3Presigner;
     private final AwsProperties awsProperties;
 
-    // S3에 대한 presigned PUT URL을 생성한다.
-    // Content-Type을 서명에 넣지 않아, 클라이언트가 보내는 Content-Type과 불일치로 403이 나지 않도록 함.
-    // 클라이언트는 응답의 requiredHeaders(Content-Type)를 PUT 요청에 넣어 객체 메타데이터를 설정할 수 있다.
+    /**
+     * S3에 대한 presigned PUT URL을 생성한다.
+     * Content-Type을 PutObjectRequest에 포함시켜 서명(SignedHeaders)에 넣는다.
+     * 클라이언트는 반드시 requiredHeaders의 Content-Type을 PUT 요청 헤더에 동일하게 설정해야 한다.
+     */
     public PresignedUpload presignPut(String objectKey, String contentType, Duration duration) {
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(awsProperties.getS3().getBucketName())
                 .key(objectKey)
+                .contentType(contentType)
                 .build();
 
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
@@ -43,7 +46,14 @@ public class S3MediaClient {
 
         PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(presignRequest);
         URL url = presigned.url();
-        return new PresignedUpload(url.toString(), Map.of("Content-Type", contentType));
+        Map<String, String> headers = new java.util.LinkedHashMap<>();
+        headers.put("Content-Type", contentType);
+        presigned.signedHeaders().forEach((k, v) -> {
+            if (!k.equalsIgnoreCase("host") && !k.equalsIgnoreCase("content-type")) {
+                headers.put(k, v.stream().findFirst().orElse(""));
+            }
+        });
+        return new PresignedUpload(url.toString(), headers);
     }
 
     // S3 HEAD로 객체 메타데이터를 조회한다. 없으면 null 반환.

--- a/frontend/app/artist-console/page.js
+++ b/frontend/app/artist-console/page.js
@@ -11,6 +11,7 @@ import Surface from "@/components/ui/Surface";
 import SectionTitle from "@/components/ui/SectionTitle";
 import Button from "@/components/ui/Button";
 import PostFeed from "@/components/PostFeed";
+import ProfileImageModal from "@/components/common/ProfileImageModal";
 
 function getCurrentUser() {
     if (typeof window === "undefined") return null;
@@ -127,6 +128,7 @@ export default function ArtistConsolePage() {
         attachmentPreviews: newPostAttachmentPreviews,
         addAttachment: addNewPostAttachment,
         removeAttachment: removeNewPostAttachment,
+        setRepresentative: setNewPostRepresentative,
         resetAttachments: resetNewPostAttachments,
         canAddAttachment: canAddNewPostAttachment,
         uploading: newPostUploading,
@@ -152,6 +154,7 @@ export default function ArtistConsolePage() {
     const fanPostsBottomRef = useRef(null);
 
     const [endedLives, setEndedLives] = useState([]);
+    const [showProfileImageModal, setShowProfileImageModal] = useState(false);
 
     // Concerts 탭 (인라인 목록)
     const [concertsList, setConcertsList] = useState([]);
@@ -506,11 +509,20 @@ export default function ArtistConsolePage() {
                 variant="primary"
                 className="p-10 flex flex-col md:flex-row items-center gap-8 relative overflow-hidden"
             >
-                <img
-                    src={displayAvatar || getDefaultAvatarUrl(displayName)}
-                    className="size-32 rounded-2xl border-2 border-white/[0.08] shrink-0 object-cover"
-                    alt=""
-                />
+                <div className="relative group shrink-0">
+                    <img
+                        src={displayAvatar || getDefaultAvatarUrl(displayName)}
+                        className="size-32 rounded-2xl border-2 border-white/[0.08] object-cover"
+                        alt=""
+                    />
+                    <button
+                        type="button"
+                        onClick={() => setShowProfileImageModal(true)}
+                        className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity text-white text-xs font-bold"
+                    >
+                        사진 변경
+                    </button>
+                </div>
                 <div className="flex-1 text-center md:text-left min-w-0">
                     <SectionTitle className="text-3xl font-black">
                         {displayName} Studio
@@ -857,13 +869,19 @@ export default function ArtistConsolePage() {
 
                         {/* 첨부파일 */}
                         <div className="mt-5">
-                            <div className="flex items-center gap-2 mb-2">
+                            <div className="flex items-center gap-2 mb-3">
+                                <span className="material-symbols-outlined text-sm text-white/40">attach_file</span>
                                 <span className="text-[10px] font-black uppercase tracking-widest text-white/55">
                                     첨부파일
                                 </span>
                                 <span className="text-[10px] font-bold text-white/40">
                                     {newPostMediaAssetIds.length}/{MAX_POST_ATTACHMENTS}
                                 </span>
+                                {newPostAttachmentPreviews.length > 1 && (
+                                    <span className="text-[9px] text-violet-400/70 ml-auto">
+                                        클릭하여 대표 이미지 선택
+                                    </span>
+                                )}
                             </div>
                             <input ref={newPostFileInputRef} type="file" accept="image/*,video/*" className="hidden" onChange={handleNewPostFileChange} />
                             {newPostUploadError && (
@@ -871,27 +889,58 @@ export default function ArtistConsolePage() {
                             )}
                             {newPostAttachmentPreviews.length > 0 ? (
                                 <div className="space-y-3">
-                                    {newPostAttachmentPreviews.map((p) => (
-                                        <div key={p.mediaAssetId} className="relative rounded-2xl overflow-hidden border border-white/[0.08]">
-                                            {p.isVideo ? (
-                                                <div className="w-full h-48 bg-black/30 flex items-center justify-center">
-                                                    <span className="material-symbols-outlined text-5xl text-white/40">videocam</span>
+                                    <div className="grid grid-cols-2 gap-3">
+                                        {newPostAttachmentPreviews.map((p, idx) => {
+                                            const isRepresentative = p.mediaAssetId === newPostRepresentativeId;
+                                            return (
+                                                <div
+                                                    key={p.mediaAssetId}
+                                                    className={`relative rounded-2xl overflow-hidden border-2 cursor-pointer transition-colors ${
+                                                        isRepresentative
+                                                            ? "border-violet-500 ring-1 ring-violet-500/30"
+                                                            : "border-white/[0.08] hover:border-white/20"
+                                                    }`}
+                                                    onClick={() => !p.isVideo && setNewPostRepresentative(p.mediaAssetId)}
+                                                >
+                                                    {p.isVideo ? (
+                                                        <div className="w-full aspect-video bg-black/30 flex flex-col items-center justify-center gap-1">
+                                                            <span className="material-symbols-outlined text-4xl text-white/40">videocam</span>
+                                                            <span className="text-[9px] text-white/30 font-bold">VIDEO</span>
+                                                        </div>
+                                                    ) : (
+                                                        <img src={p.url} alt={`첨부 ${idx + 1}`} className="w-full aspect-video object-cover bg-black/20" />
+                                                    )}
+                                                    {isRepresentative && (
+                                                        <span className="absolute top-2 left-2 px-2 py-0.5 rounded-full bg-violet-600 text-[9px] font-bold text-white">
+                                                            대표
+                                                        </span>
+                                                    )}
+                                                    <button
+                                                        type="button"
+                                                        onClick={(e) => { e.stopPropagation(); removeNewPostAttachment(p.mediaAssetId); }}
+                                                        className="absolute top-2 right-2 size-7 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-red-600 transition-colors"
+                                                    >
+                                                        <span className="material-symbols-outlined text-sm">close</span>
+                                                    </button>
                                                 </div>
-                                            ) : (
-                                                <img src={p.url} alt="미리보기" className="w-full max-h-48 object-contain bg-black/20" />
-                                            )}
-                                            <button type="button" onClick={() => removeNewPostAttachment(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
-                                                <span className="material-symbols-outlined text-lg">close</span>
+                                            );
+                                        })}
+                                        {canAddNewPostAttachment && !newPostUploading && (
+                                            <button
+                                                type="button"
+                                                onClick={() => newPostFileInputRef.current?.click()}
+                                                className="aspect-video rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/40 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center justify-center gap-1"
+                                            >
+                                                <span className="material-symbols-outlined text-2xl">add</span>
+                                                <span className="text-[10px] font-bold">추가</span>
                                             </button>
-                                        </div>
-                                    ))}
-                                    {canAddNewPostAttachment && !newPostUploading && (
-                                        <button type="button" onClick={() => newPostFileInputRef.current?.click()} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm">
-                                            + 추가
-                                        </button>
-                                    )}
+                                        )}
+                                    </div>
                                     {newPostUploading && (
-                                        <p className="text-violet-300 text-xs py-2">업로드 중...</p>
+                                        <div className="flex items-center gap-2 py-2">
+                                            <div className="size-4 border-2 border-violet-400 border-t-transparent rounded-full animate-spin" />
+                                            <span className="text-violet-300 text-xs font-medium">업로드 중...</span>
+                                        </div>
                                     )}
                                 </div>
                             ) : (
@@ -903,6 +952,7 @@ export default function ArtistConsolePage() {
                                 >
                                     <span className="material-symbols-outlined text-3xl">add_photo_alternate</span>
                                     <span className="text-xs font-bold">{newPostUploading ? "업로드 중..." : "사진 또는 동영상 추가"}</span>
+                                    <span className="text-[10px] text-white/30">이미지·영상 최대 {MAX_POST_ATTACHMENTS}개</span>
                                 </button>
                             )}
                         </div>
@@ -928,6 +978,19 @@ export default function ArtistConsolePage() {
                     </Surface>
                 </div>
             )}
+
+            <ProfileImageModal
+                isOpen={showProfileImageModal}
+                onClose={() => setShowProfileImageModal(false)}
+                currentImageUrl={displayAvatar}
+                mode="artist"
+                onSuccess={(newUrl) => {
+                    setMyProfile((prev) => prev ? { ...prev, profileImageUrl: newUrl } : prev);
+                    if (groupId === myId) {
+                        setGroupProfile((prev) => prev ? { ...prev, profileImageUrl: newUrl } : prev);
+                    }
+                }}
+            />
         </div>
     );
 }

--- a/frontend/app/artists/[id]/page.js
+++ b/frontend/app/artists/[id]/page.js
@@ -162,10 +162,12 @@ function ArtistDetailPageInner({ paramsId }) {
         attachmentPreviews: fanPostAttachmentPreviews,
         addAttachment: addFanPostAttachment,
         removeAttachment: removeFanPostAttachment,
+        setRepresentative: setFanPostRepresentative,
         resetAttachments: resetFanPostAttachments,
         canAddAttachment: canAddFanPostAttachment,
         uploading: fanPostUploading,
         uploadError: fanPostUploadError,
+        representativeMediaAssetId: fanPostRepresentativeId,
     } = usePostAttachments({
         postGroupId: groupId,
         postIdOrTemp: "tmp_fan_new",
@@ -539,6 +541,7 @@ function ArtistDetailPageInner({ paramsId }) {
                         title: "",
                         content: newPostContent.trim(),
                         mediaAssetIds: fanPostMediaAssetIds.length > 0 ? fanPostMediaAssetIds : null,
+                        representativeMediaAssetId: fanPostRepresentativeId,
                     },
                 });
                 const newPost = transformFanPost(created);
@@ -1077,9 +1080,13 @@ function ArtistDetailPageInner({ paramsId }) {
                         />
                         {/* 첨부파일 */}
                         <div className="mt-4">
-                            <div className="flex items-center gap-2 mb-2">
+                            <div className="flex items-center gap-2 mb-3">
+                                <span className="material-symbols-outlined text-sm text-white/40">attach_file</span>
                                 <span className="text-[10px] font-black uppercase tracking-widest text-white/55">첨부파일</span>
                                 <span className="text-[10px] font-bold text-white/40">{fanPostMediaAssetIds.length}/{MAX_POST_ATTACHMENTS}</span>
+                                {fanPostAttachmentPreviews.length > 1 && (
+                                    <span className="text-[9px] text-violet-400/70 ml-auto">클릭하여 대표 이미지 선택</span>
+                                )}
                             </div>
                             <input ref={fanPostFileInputRef} type="file" accept="image/*,video/*" className="hidden" onChange={handleFanPostFileChange} />
                             {fanPostUploadError && (
@@ -1087,27 +1094,56 @@ function ArtistDetailPageInner({ paramsId }) {
                             )}
                             {fanPostAttachmentPreviews.length > 0 ? (
                                 <div className="space-y-3">
-                                    {fanPostAttachmentPreviews.map((p) => (
-                                        <div key={p.mediaAssetId} className="relative rounded-2xl overflow-hidden border border-white/[0.08]">
-                                            {p.isVideo ? (
-                                                <div className="w-full h-40 bg-black/30 flex items-center justify-center">
-                                                    <span className="material-symbols-outlined text-5xl text-white/40">videocam</span>
+                                    <div className="grid grid-cols-2 gap-3">
+                                        {fanPostAttachmentPreviews.map((p, idx) => {
+                                            const isRepresentative = p.mediaAssetId === fanPostRepresentativeId;
+                                            return (
+                                                <div
+                                                    key={p.mediaAssetId}
+                                                    className={`relative rounded-2xl overflow-hidden border-2 cursor-pointer transition-colors ${
+                                                        isRepresentative
+                                                            ? "border-violet-500 ring-1 ring-violet-500/30"
+                                                            : "border-white/[0.08] hover:border-white/20"
+                                                    }`}
+                                                    onClick={() => !p.isVideo && setFanPostRepresentative(p.mediaAssetId)}
+                                                >
+                                                    {p.isVideo ? (
+                                                        <div className="w-full aspect-video bg-black/30 flex flex-col items-center justify-center gap-1">
+                                                            <span className="material-symbols-outlined text-4xl text-white/40">videocam</span>
+                                                            <span className="text-[9px] text-white/30 font-bold">VIDEO</span>
+                                                        </div>
+                                                    ) : (
+                                                        <img src={p.url} alt={`첨부 ${idx + 1}`} className="w-full aspect-video object-cover bg-black/20" />
+                                                    )}
+                                                    {isRepresentative && (
+                                                        <span className="absolute top-2 left-2 px-2 py-0.5 rounded-full bg-violet-600 text-[9px] font-bold text-white">대표</span>
+                                                    )}
+                                                    <button
+                                                        type="button"
+                                                        onClick={(e) => { e.stopPropagation(); removeFanPostAttachment(p.mediaAssetId); }}
+                                                        className="absolute top-2 right-2 size-7 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-red-600 transition-colors"
+                                                    >
+                                                        <span className="material-symbols-outlined text-sm">close</span>
+                                                    </button>
                                                 </div>
-                                            ) : (
-                                                <img src={p.url} alt="미리보기" className="w-full max-h-40 object-contain bg-black/20" />
-                                            )}
-                                            <button type="button" onClick={() => removeFanPostAttachment(p.mediaAssetId)} className="absolute top-2 right-2 size-8 rounded-full bg-black/60 text-white flex items-center justify-center hover:bg-black/80">
-                                                <span className="material-symbols-outlined text-lg">close</span>
+                                            );
+                                        })}
+                                        {canAddFanPostAttachment && !fanPostUploading && (
+                                            <button
+                                                type="button"
+                                                onClick={() => fanPostFileInputRef.current?.click()}
+                                                className="aspect-video rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/40 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex flex-col items-center justify-center gap-1"
+                                            >
+                                                <span className="material-symbols-outlined text-2xl">add</span>
+                                                <span className="text-[10px] font-bold">추가</span>
                                             </button>
-                                        </div>
-                                    ))}
-                                    {canAddFanPostAttachment && !fanPostUploading && (
-                                        <button type="button" onClick={() => fanPostFileInputRef.current?.click()} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 text-sm">
-                                            + 추가
-                                        </button>
-                                    )}
+                                        )}
+                                    </div>
                                     {fanPostUploading && (
-                                        <p className="text-violet-300 text-xs py-2">업로드 중...</p>
+                                        <div className="flex items-center gap-2 py-2">
+                                            <div className="size-4 border-2 border-violet-400 border-t-transparent rounded-full animate-spin" />
+                                            <span className="text-violet-300 text-xs font-medium">업로드 중...</span>
+                                        </div>
                                     )}
                                 </div>
                             ) : (
@@ -1119,6 +1155,7 @@ function ArtistDetailPageInner({ paramsId }) {
                                 >
                                     <span className="material-symbols-outlined text-3xl">add_photo_alternate</span>
                                     <span className="text-xs font-bold">{fanPostUploading ? "업로드 중..." : "사진 또는 동영상 추가"}</span>
+                                    <span className="text-[10px] text-white/30">이미지·영상 최대 {MAX_POST_ATTACHMENTS}개</span>
                                 </button>
                             )}
                         </div>

--- a/frontend/app/mypage/page.js
+++ b/frontend/app/mypage/page.js
@@ -12,6 +12,7 @@ import { redirectToGuestHome } from "@/lib/authRedirect";
 import { BASE_URL, request, getAuthHeaders } from "@/lib/api";
 import { useMediaUpload } from "@/lib/useMediaUpload";
 import { MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
+import ProfileImageModal from "@/components/common/ProfileImageModal";
 
 /** JWT payload에서 관리자 여부 판단 (API 호출 없이, 403 방지) */
 function getIsAdminFromToken() {
@@ -43,12 +44,7 @@ function MyPageContent() {
   const [pwLoading, setPwLoading] = useState(false);
   const [pwMessage, setPwMessage] = useState("");
 
-  const [showProfileImageEdit, setShowProfileImageEdit] = useState(false);
-  const [profileImageMediaAssetId, setProfileImageMediaAssetId] = useState(null);
-  const [profileImagePreviewUrl, setProfileImagePreviewUrl] = useState(null);
-  const [profileImageLoading, setProfileImageLoading] = useState(false);
-  const [profileImageMessage, setProfileImageMessage] = useState("");
-  const fanProfileImageInputRef = useRef(null);
+  const [showProfileImageModal, setShowProfileImageModal] = useState(false);
 
   const [isAdmin, setIsAdmin] = useState(false);
 
@@ -201,46 +197,12 @@ function MyPageContent() {
     }
   };
 
-  const handleFanProfileImageUpload = async (e) => {
-    const file = e?.target?.files?.[0];
-    if (!file || !file.type.startsWith("image/") || !uploadProfileImage) return;
-    const result = await uploadProfileImage(file);
-    if (result?.mediaAssetId && result?.url) {
-      setProfileImageMediaAssetId(result.mediaAssetId);
-      setProfileImagePreviewUrl(result.url);
-    }
-    e.target.value = "";
-  };
-
-  const handleProfileImageSubmit = async () => {
-    if (!profileImageMediaAssetId) return;
-    setProfileImageMessage("");
-    setProfileImageLoading(true);
-    try {
-      const headers = getAuthHeaders();
-      await axios.put(
-        `${BASE_URL}/api/user/profile`,
-        {
-          nickname: data?.profile?.nickname ?? "",
-          profileImageMediaAssetId,
-        },
-        { headers }
-      );
-      const newUrl = profileImagePreviewUrl;
-      setData((prev) =>
-        prev && prev.profile
-          ? { ...prev, profile: { ...prev.profile, profileImageUrl: newUrl } }
-          : prev
-      );
-      setProfileImageMessage("저장되었습니다.");
-      setShowProfileImageEdit(false);
-      setProfileImageMediaAssetId(null);
-      setProfileImagePreviewUrl(null);
-    } catch (e) {
-      setProfileImageMessage(e.response?.data?.message ?? "저장에 실패했습니다.");
-    } finally {
-      setProfileImageLoading(false);
-    }
+  const handleProfileImageSuccess = (newUrl) => {
+    setData((prev) =>
+      prev && prev.profile
+        ? { ...prev, profile: { ...prev.profile, profileImageUrl: newUrl } }
+        : prev
+    );
   };
 
   const handleNicknameSave = async () => {
@@ -466,12 +428,7 @@ function MyPageContent() {
                 </div>
                 <button
                   type="button"
-                  onClick={() => {
-                    setShowProfileImageEdit(true);
-                    setProfileImageMediaAssetId(null);
-                    setProfileImagePreviewUrl(null);
-                    setProfileImageMessage("");
-                  }}
+                  onClick={() => setShowProfileImageModal(true)}
                   className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity text-white text-xs font-bold"
                 >
                   사진 변경
@@ -746,12 +703,7 @@ function MyPageContent() {
             </div>
             <button
               type="button"
-              onClick={() => {
-                setShowProfileImageEdit(true);
-                setProfileImageMediaAssetId(null);
-                setProfileImagePreviewUrl(null);
-                setProfileImageMessage("");
-              }}
+              onClick={() => setShowProfileImageModal(true)}
               className="absolute inset-0 flex items-center justify-center rounded-2xl bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity text-white text-xs font-bold"
             >
               사진 변경
@@ -789,49 +741,14 @@ function MyPageContent() {
         </>
       )}
 
-      {showProfileImageEdit && (
-        <Surface variant="primary" className="p-6 max-w-md">
-          <h3 className="text-lg font-semibold text-white mb-4">프로필 이미지 변경</h3>
-          <div className="space-y-3">
-            <input ref={fanProfileImageInputRef} type="file" accept="image/*" className="hidden" onChange={handleFanProfileImageUpload} />
-            {profileImagePreviewUrl ? (
-              <div className="relative inline-block">
-                <img src={profileImagePreviewUrl} alt="미리보기" className="size-24 rounded-xl object-cover border border-white/10" />
-                <button type="button" onClick={() => { setProfileImagePreviewUrl(null); setProfileImageMediaAssetId(null); }} className="absolute -top-1 -right-1 size-6 rounded-full bg-red-500 text-white text-xs">×</button>
-              </div>
-            ) : (
-              <button type="button" onClick={() => fanProfileImageInputRef.current?.click()} className="py-4 px-6 rounded-xl border-2 border-dashed border-white/20 text-white/60 hover:border-violet-500/40 hover:text-violet-300 text-sm w-full">
-                사진 선택 (파일 탐색기)
-              </button>
-            )}
-            {profileImageMessage && (
-              <p className="text-xs text-white/70">{profileImageMessage}</p>
-            )}
-            <div className="flex gap-2 pt-2">
-              <Button
-                variant="primary"
-                className="flex-1 py-2.5 text-xs"
-                onClick={handleProfileImageSubmit}
-                disabled={profileImageLoading || !profileImageMediaAssetId}
-              >
-                {profileImageLoading ? "저장 중..." : "저장"}
-              </Button>
-              <Button
-                variant="ghost"
-                className="py-2.5 text-xs border border-white/10"
-                onClick={() => {
-                  setShowProfileImageEdit(false);
-                  setProfileImageMediaAssetId(null);
-                  setProfileImagePreviewUrl(null);
-                  setProfileImageMessage("");
-                }}
-              >
-                취소
-              </Button>
-            </div>
-          </div>
-        </Surface>
-      )}
+      <ProfileImageModal
+        isOpen={showProfileImageModal}
+        onClose={() => setShowProfileImageModal(false)}
+        currentImageUrl={profile?.profileImageUrl}
+        mode={isArtistAccount ? "artist" : "fan"}
+        nickname={data?.profile?.nickname ?? ""}
+        onSuccess={handleProfileImageSuccess}
+      />
 
       {!isFan && (
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-10">

--- a/frontend/components/common/ProfileImageModal.jsx
+++ b/frontend/components/common/ProfileImageModal.jsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { useMediaUpload } from "@/lib/useMediaUpload";
+import { MediaAssetCategory, MediaAssetScope } from "@/lib/mediaAssetApi";
+import { BASE_URL, getAuthHeaders, request } from "@/lib/api";
+import axios from "axios";
+import Surface from "@/components/ui/Surface";
+import Button from "@/components/ui/Button";
+
+/**
+ * 프로필 이미지 변경 모달 (팬/아티스트 공용).
+ *
+ * @param {boolean} isOpen
+ * @param {Function} onClose
+ * @param {string|null} currentImageUrl - 현재 프로필 이미지
+ * @param {"fan"|"artist"} mode - 팬: PUT /api/user/profile, 아티스트: PATCH /api/artist/profile
+ * @param {string} nickname - 팬 모드에서 필요
+ * @param {Function} onSuccess - (newUrl) => void
+ */
+export default function ProfileImageModal({
+  isOpen,
+  onClose,
+  currentImageUrl,
+  mode = "fan",
+  nickname = "",
+  onSuccess,
+}) {
+  const [mediaAssetId, setMediaAssetId] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const fileInputRef = useRef(null);
+
+  const presignItem = {
+    category: MediaAssetCategory.PROFILE_IMAGE,
+    scope: MediaAssetScope.PUBLIC,
+  };
+  const { upload, loading: uploading } = useMediaUpload(presignItem);
+
+  const handleFileChange = useCallback(
+    async (e) => {
+      const file = e?.target?.files?.[0];
+      if (!file || !file.type.startsWith("image/") || !upload) return;
+      setMessage("");
+      const result = await upload(file);
+      if (result?.mediaAssetId && result?.url) {
+        setMediaAssetId(result.mediaAssetId);
+        setPreviewUrl(result.url);
+      }
+      e.target.value = "";
+    },
+    [upload],
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!mediaAssetId) return;
+    setSaving(true);
+    setMessage("");
+    try {
+      if (mode === "artist") {
+        await request("/api/artist/profile", {
+          method: "PATCH",
+          body: { profileImageMediaAssetId: mediaAssetId },
+        });
+      } else {
+        const headers = getAuthHeaders();
+        await axios.put(
+          `${BASE_URL}/api/user/profile`,
+          { nickname, profileImageMediaAssetId: mediaAssetId },
+          { headers },
+        );
+      }
+      onSuccess?.(previewUrl);
+      handleClose();
+    } catch (e) {
+      setMessage(
+        e?.response?.data?.message ?? e?.data?.message ?? e?.message ?? "저장에 실패했습니다.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [mediaAssetId, mode, nickname, previewUrl, onSuccess]);
+
+  const handleClose = useCallback(() => {
+    setMediaAssetId(null);
+    setPreviewUrl(null);
+    setMessage("");
+    onClose?.();
+  }, [onClose]);
+
+  if (!isOpen) return null;
+
+  const displayUrl = previewUrl || currentImageUrl;
+
+  return (
+    <div
+      className="fixed inset-0 z-[110] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+      onClick={handleClose}
+    >
+      <Surface
+        variant="primary"
+        className="w-full max-w-md p-8 relative"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center mb-6">
+          <h3 className="text-lg font-bold text-white">프로필 이미지 변경</h3>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="size-8 rounded-full bg-white/[0.08] flex items-center justify-center text-white/80 hover:bg-white/[0.12] transition-colors"
+          >
+            <span className="material-symbols-outlined text-lg">close</span>
+          </button>
+        </div>
+
+        <div className="flex flex-col items-center gap-5">
+          {/* 현재/미리보기 이미지 */}
+          <div className="relative group">
+            <div className="size-32 rounded-full overflow-hidden border-2 border-white/[0.08] bg-[#201a33]">
+              {displayUrl ? (
+                <img
+                  src={displayUrl}
+                  alt="프로필"
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center">
+                  <span className="material-symbols-outlined text-5xl text-white/20">
+                    person
+                  </span>
+                </div>
+              )}
+            </div>
+            {previewUrl && (
+              <span className="absolute -bottom-1 left-1/2 -translate-x-1/2 px-2 py-0.5 rounded-full bg-violet-600 text-[9px] font-bold text-white">
+                미리보기
+              </span>
+            )}
+          </div>
+
+          {/* 파일 선택 */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="w-full py-4 rounded-2xl border-2 border-dashed border-white/[0.12] bg-white/[0.02] text-white/50 hover:border-violet-500/30 hover:text-violet-300/70 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+          >
+            <span className="material-symbols-outlined text-xl">
+              add_photo_alternate
+            </span>
+            <span className="text-sm font-bold">
+              {uploading ? "업로드 중..." : "새 이미지 선택"}
+            </span>
+          </button>
+
+          {message && (
+            <p className="text-xs text-red-400 text-center">{message}</p>
+          )}
+
+          {/* 버튼 */}
+          <div className="flex gap-3 w-full pt-2">
+            <Button
+              variant="ghost"
+              className="flex-1 py-3 text-sm"
+              onClick={handleClose}
+            >
+              취소
+            </Button>
+            <Button
+              variant="primary"
+              className="flex-1 py-3 text-sm"
+              onClick={handleSave}
+              disabled={saving || uploading || !mediaAssetId}
+            >
+              {saving ? "저장 중..." : "저장"}
+            </Button>
+          </div>
+        </div>
+      </Surface>
+    </div>
+  );
+}

--- a/frontend/lib/mediaAssetApi.js
+++ b/frontend/lib/mediaAssetApi.js
@@ -106,27 +106,34 @@ export async function uploadFile(file, presignItem) {
   }
   if (!presignResults?.[0]) throw new Error("Presign 응답이 비어 있습니다.");
   const { objectKey, uploadUrl, requiredHeaders } = presignResults[0];
-  // S3 presigned PUT: 서명에 포함된 헤더와 일치시켜야 403 방지. Content-Type은 requiredHeaders 값 우선.
-  const signedContentType =
-    (requiredHeaders && (requiredHeaders["Content-Type"] ?? requiredHeaders["content-type"])) || null;
+
+  // requiredHeaders에서 서명된 헤더를 구성 (Content-Type 포함)
   const putHeaders = {};
-  if (signedContentType) {
-    putHeaders["Content-Type"] = signedContentType;
-  } else {
+  if (requiredHeaders && typeof requiredHeaders === "object") {
+    for (const [k, v] of Object.entries(requiredHeaders)) {
+      if (k.toLowerCase() !== "host") {
+        putHeaders[k] = v;
+      }
+    }
+  }
+  if (!putHeaders["Content-Type"] && !putHeaders["content-type"]) {
     putHeaders["Content-Type"] = contentType;
   }
+
+  // File 객체를 Blob으로 변환하여 브라우저가 자동으로 Content-Type을 추가하는 것을 방지
+  const blob = new Blob([file], { type: putHeaders["Content-Type"] || contentType });
 
   let putRes = await fetch(uploadUrl, {
     method: "PUT",
     headers: putHeaders,
-    body: file,
+    body: blob,
   });
-  // 403 시: 백엔드가 Content-Type을 서명에 넣지 않은 경우, 헤더 없이 재시도(일부 환경에서만 필요)
-  if (putRes.status === 403 && putHeaders["Content-Type"]) {
+  // 403 재시도: Content-Type 없이 순수 바이너리로 전송
+  if (putRes.status === 403) {
+    const rawBlob = new Blob([file]);
     putRes = await fetch(uploadUrl, {
       method: "PUT",
-      headers: {},
-      body: file,
+      body: rawBlob,
     });
   }
   if (!putRes.ok) {

--- a/frontend/lib/usePostAttachments.js
+++ b/frontend/lib/usePostAttachments.js
@@ -94,6 +94,25 @@ export function usePostAttachments({ postGroupId, postIdOrTemp, initialAttachmen
     );
   }, []);
 
+  const setRepresentative = useCallback((mediaAssetId) => {
+    setMediaAssetIds((prev) => {
+      const idx = prev.indexOf(mediaAssetId);
+      if (idx <= 0) return prev;
+      const next = [...prev];
+      next.splice(idx, 1);
+      next.unshift(mediaAssetId);
+      return next;
+    });
+    setAttachmentPreviews((prev) => {
+      const idx = prev.findIndex((p) => p.mediaAssetId === mediaAssetId);
+      if (idx <= 0) return prev;
+      const next = [...prev];
+      const [item] = next.splice(idx, 1);
+      next.unshift(item);
+      return next;
+    });
+  }, []);
+
   const resetAttachments = useCallback(() => {
     setMediaAssetIds([]);
     setAttachmentPreviews([]);
@@ -106,6 +125,7 @@ export function usePostAttachments({ postGroupId, postIdOrTemp, initialAttachmen
     attachmentPreviews,
     addAttachment,
     removeAttachment,
+    setRepresentative,
     setAttachmentsFromApi,
     resetAttachments,
     canAddAttachment: canAdd,


### PR DESCRIPTION
S3 업로드 403 에러 근본 원인 (IAM 정책)
문제: ObjectKeyGenerator가 생성하는 S3 키에는 public/, restricted/, raw/ 접두사가 있으나, IAM 정책의 Resource에는 이 접두사가 빠져 있어 모든 PutObject가 AccessDenied 됨


프로필 이미지 변경 모달
- 새로 생성한 파일:

frontend/components/common/ProfileImageModal.jsx - 팬/아티스트 공용 프로필 이미지 변경 모달

- 변경점:

mypage: 기존 인라인 Surface 편집 UI → 오버레이 모달로 교체. 프로필 이미지에 hover 시 "사진 변경" 버튼 → 모달 오픈. 팬/아티스트 mode 자동 판별

artist-console: 프로필 이미지에 hover 시 "사진 변경" 버튼 추가 → 모달 오픈. 변경 후 로컬 state 즉시 반영

불필요한 state 6개, handler 2개, ref 1개 제거 (팬 프로필 인라인 편집 관련)

 포스트 작성 모달 개선

- 변경 파일:

frontend/lib/usePostAttachments.js - setRepresentative() 함수 추가 (대표 이미지 선택 기능)

frontend/app/artist-console/page.js - 첨부파일 UI 개선

frontend/app/artists/[id]/page.js - 팬 포스트 첨부파일 UI 개선

- 개선 내용:

첨부파일을 2열 그리드 레이아웃으로 변경 (기존: 세로 쭉 나열)

대표 이미지 표시: 첫 번째 이미지에 보라색 "대표" 뱃지 + 테두리 하이라이트

대표 이미지 선택: 이미지 클릭 시 해당 이미지를 대표로 변경 (게시물 미리보기에 사용됨)

파일 개수 안내: "이미지·영상 최대 5개" 안내 텍스트 추가

업로드 중 스피너: 텍스트만 있던 로딩 → 회전 아이콘 + 텍스트

삭제 버튼: hover 시 빨간색으로 변경되는 인터랙션 추가

팬 포스트 생성 시 representativeMediaAssetId 전달 추가