### PR TITLE
fix: 프론트 코드 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/replay/dto/ReplayCreateManualRequest.java
+++ b/backend/src/main/java/org/example/backend/replay/dto/ReplayCreateManualRequest.java
@@ -11,6 +11,8 @@ public record ReplayCreateManualRequest(
         @NotNull
         Long artistId,
         @NotNull
-        ReplayAccessType accessType
+        ReplayAccessType accessType,
+        @jakarta.validation.constraints.Size(max = 200)
+        String title
 ) {
 }

--- a/backend/src/main/java/org/example/backend/replay/dto/ReplayResponse.java
+++ b/backend/src/main/java/org/example/backend/replay/dto/ReplayResponse.java
@@ -12,6 +12,7 @@ public record ReplayResponse(
         Long liveSessionId,
         ReplayAccessType accessType,
         ReplayStatus status,
+        String title,
         String playbackUrl,
         String playbackPathPattern,
         String thumbnailUrl,

--- a/backend/src/main/java/org/example/backend/replay/entity/Replay.java
+++ b/backend/src/main/java/org/example/backend/replay/entity/Replay.java
@@ -48,6 +48,9 @@ public class Replay {
     @Column(name = "status", nullable = false, length = 20)
     private ReplayStatus status;
 
+    @Column(name = "title", length = 200)
+    private String title;
+
     @Column(name = "recording_s3_bucket", length = 255)
     private String recordingS3Bucket;
 
@@ -80,7 +83,6 @@ public class Replay {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
-    // Replay 엔티티를 생성한다.
     public Replay(Long artistId,
                   Long liveSessionId,
                   ReplayAccessType accessType,
@@ -88,6 +90,17 @@ public class Replay {
                   String recordingS3Bucket,
                   String recordingS3Prefix,
                   Instant publishedAt) {
+        this(artistId, liveSessionId, accessType, status, recordingS3Bucket, recordingS3Prefix, publishedAt, null);
+    }
+
+    public Replay(Long artistId,
+                  Long liveSessionId,
+                  ReplayAccessType accessType,
+                  ReplayStatus status,
+                  String recordingS3Bucket,
+                  String recordingS3Prefix,
+                  Instant publishedAt,
+                  String title) {
         this.artistId = artistId;
         this.liveSessionId = liveSessionId;
         this.accessType = accessType;
@@ -95,6 +108,7 @@ public class Replay {
         this.recordingS3Bucket = recordingS3Bucket;
         this.recordingS3Prefix = recordingS3Prefix;
         this.publishedAt = publishedAt;
+        this.title = title;
     }
 
     // Replay 상태를 변경한다.
@@ -133,7 +147,10 @@ public class Replay {
         this.rejectReason = rejectReason;
     }
 
-    /** 수동 업로드 발행: 상태를 PUBLISHED로 하고 발행 시각을 기록한다. */
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
     public void markPublished(Instant at) {
         this.status = ReplayStatus.PUBLISHED;
         this.publishedAt = at;

--- a/backend/src/main/java/org/example/backend/replay/service/ReplayCommandService.java
+++ b/backend/src/main/java/org/example/backend/replay/service/ReplayCommandService.java
@@ -89,8 +89,12 @@ public class ReplayCommandService {
                     ReplayStatus.PUBLISHED,
                     session.recordingS3Bucket(),
                     session.recordingS3Prefix(),
-                    now
+                    now,
+                    request.title()
             );
+        }
+        if (request.title() != null && !request.title().isBlank()) {
+            replay.updateTitle(request.title().trim());
         }
         replayRepository.save(replay);
 
@@ -181,7 +185,8 @@ public class ReplayCommandService {
                 ReplayStatus.UPLOADING,
                 null,
                 null,
-                null
+                null,
+                request.title() != null ? request.title().trim() : null
         );
         replayRepository.save(replay);
         return new ReplayCreateManualResponse(

--- a/backend/src/main/java/org/example/backend/replay/service/ReplayQueryService.java
+++ b/backend/src/main/java/org/example/backend/replay/service/ReplayQueryService.java
@@ -84,6 +84,7 @@ public class ReplayQueryService {
                 replay.getLiveSessionId(),
                 replay.getAccessType(),
                 replay.getStatus(),
+                replay.getTitle(),
                 playbackUrl,
                 pattern,
                 thumbnailUrl,

--- a/frontend/app/artist-console/live/page.js
+++ b/frontend/app/artist-console/live/page.js
@@ -163,6 +163,7 @@ export default function ArtistLivePage() {
     const [manualStep, setManualStep] = useState("idle"); // idle | created | uploading | processing | ready | published
     const [manualReplay, setManualReplay] = useState(null);
     const [manualAccessType, setManualAccessType] = useState(ReplayAccessType.FREE);
+    const [manualTitle, setManualTitle] = useState("");
     const [manualError, setManualError] = useState("");
     const [manualPublishing, setManualPublishing] = useState(false);
     const manualVideoPresignItem = manualReplay?.replayId
@@ -245,7 +246,11 @@ export default function ArtistLivePage() {
         }
         setManualError("");
         try {
-            const res = await createManualReplay({ artistId: numericArtistId, accessType: manualAccessType });
+            const res = await createManualReplay({
+                artistId: numericArtistId,
+                accessType: manualAccessType,
+                title: manualTitle.trim() || null,
+            });
             setManualReplay({
                 replayId: res.replayId,
                 artistId: res.artistId,
@@ -312,6 +317,7 @@ export default function ArtistLivePage() {
     const resetManualFlow = () => {
         setManualStep("idle");
         setManualReplay(null);
+        setManualTitle("");
         setManualError("");
     };
 
@@ -495,22 +501,8 @@ export default function ArtistLivePage() {
                     다시보기 발행
                 </SectionTitle>
                 <p className="text-sm text-white/55 mb-4">
-                    녹화 완료된 라이브 세션을 다시보기로 발행합니다. (ARTIST 본인 artistId
-                    필요)
+                    녹화 완료된 라이브 세션을 다시보기로 발행합니다.
                 </p>
-
-                <label className="block mb-3">
-          <span className="text-[10px] font-black uppercase tracking-widest text-white/55">
-            artistId
-          </span>
-                    <input
-                        type="number"
-                        min="1"
-                        value={artistId != null ? artistId : ""}
-                        onChange={(e) => setArtistId(Number(e.target.value) || null)}
-                        className="mt-1 w-24 bg-[#16102a] border border-white/[0.08] rounded-lg px-3 py-2 text-white"
-                    />
-                </label>
 
                 {publishError && (
                     <p className="text-red-400 text-sm mb-3">{publishError}</p>
@@ -567,14 +559,14 @@ export default function ArtistLivePage() {
                             }
                             className="mt-1 w-full bg-[#16102a] border border-white/[0.08] rounded-lg px-3 py-2 text-white"
                         >
-                            <option value={ReplayAccessType.FREE}>FREE</option>
-                            <option value={ReplayAccessType.PAID}>PAID</option>
+                            <option value={ReplayAccessType.FREE}>무료 (전체 공개)</option>
+                            <option value={ReplayAccessType.PAID}>유료 (멤버십 전용)</option>
                         </select>
                     </label>
 
                     <label className="block">
             <span className="text-[10px] font-black uppercase tracking-widest text-white/55">
-              제목 (선택)
+              제목
             </span>
                         <input
                             type="text"
@@ -583,7 +575,8 @@ export default function ArtistLivePage() {
                             onChange={(e) =>
                                 setPublishForm((f) => ({ ...f, title: e.target.value }))
                             }
-                            className="mt-1 w-full bg-[#16102a] border border-white/[0.08] rounded-lg px-3 py-2 text-white"
+                            placeholder="다시보기 제목을 입력하세요"
+                            className="mt-1 w-full bg-[#16102a] border border-white/[0.08] rounded-lg px-3 py-2 text-white placeholder:text-white/30"
                         />
                     </label>
 
@@ -639,17 +632,28 @@ export default function ArtistLivePage() {
                 {manualStep === "idle" && (
                     <form onSubmit={handleCreateManualSlot} className="space-y-3 max-w-md">
                         <label className="block">
+                            <span className="text-[10px] font-black uppercase tracking-widest text-white/55">제목</span>
+                            <input
+                                type="text"
+                                maxLength={200}
+                                value={manualTitle}
+                                onChange={(e) => setManualTitle(e.target.value)}
+                                placeholder="다시보기 제목을 입력하세요"
+                                className="mt-1 w-full bg-[#16102a] border border-white/[0.08] rounded-lg px-3 py-2 text-white placeholder:text-white/30"
+                            />
+                        </label>
+                        <label className="block">
                             <span className="text-[10px] font-black uppercase tracking-widest text-white/55">접근 타입</span>
                             <select
                                 value={manualAccessType}
                                 onChange={(e) => setManualAccessType(e.target.value)}
                                 className="mt-1 w-full bg-[#16102a] border border-white/[0.08] rounded-lg px-3 py-2 text-white"
                             >
-                                <option value={ReplayAccessType.FREE}>FREE</option>
-                                <option value={ReplayAccessType.PAID}>PAID</option>
+                                <option value={ReplayAccessType.FREE}>무료 (전체 공개)</option>
+                                <option value={ReplayAccessType.PAID}>유료 (멤버십 전용)</option>
                             </select>
                         </label>
-                        <Button type="submit" variant="primary">슬롯 생성 후 영상 업로드</Button>
+                        <Button type="submit" variant="primary">영상 업로드 시작</Button>
                     </form>
                 )}
 

--- a/frontend/app/artist-console/page.js
+++ b/frontend/app/artist-console/page.js
@@ -890,10 +890,10 @@ export default function ArtistConsolePage() {
                                         </h4>
                                         <Button
                                             variant="primary"
-                                            href={live.id ? `/artist-console/live/${live.id}` : "#"}
+                                            href="/artist-console/live"
                                             className="w-full py-3 text-[10px] uppercase tracking-widest"
                                         >
-                                            다시보기
+                                            다시보기 관리
                                         </Button>
                                     </div>
                                 </Surface>

--- a/frontend/app/artists/[id]/page.js
+++ b/frontend/app/artists/[id]/page.js
@@ -957,13 +957,26 @@ function ArtistDetailPageInner({ paramsId }) {
                                     <div className="grid grid-cols-2 gap-6">
                                         {vodList.map((vod) => (
                                             <Link key={vod.replayId} href={`/replay/${vod.replayId}`} className="group">
-                                                <div className="aspect-video rounded-2xl overflow-hidden relative mb-3">
-                                                    <img src={vod.thumbnailUrl || "https://picsum.photos/seed/vod/800/450"} className="w-full h-full object-cover" alt="" />
+                                                <div className="aspect-video rounded-2xl overflow-hidden relative mb-3 bg-gradient-to-br from-violet-900/30 to-indigo-900/20 border border-white/[0.06]">
+                                                    {vod.thumbnailUrl ? (
+                                                        <img src={vod.thumbnailUrl} className="w-full h-full object-cover" alt="" />
+                                                    ) : (
+                                                        <div className="w-full h-full flex items-center justify-center">
+                                                            <span className="material-symbols-outlined text-5xl text-white/15">smart_display</span>
+                                                        </div>
+                                                    )}
                                                     <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/40 transition-opacity">
-                                                        <span className="material-symbols-outlined text-white text-5xl">play_circle</span>
+                                                        <div className="size-12 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center">
+                                                            <span className="material-symbols-outlined text-white text-3xl fill-icon">play_arrow</span>
+                                                        </div>
                                                     </div>
+                                                    {vod.accessType === "PAID" && (
+                                                        <span className="absolute top-2 right-2 px-2 py-0.5 rounded-md bg-violet-500/80 text-[9px] font-black text-white uppercase">
+                                                            멤버십
+                                                        </span>
+                                                    )}
                                                 </div>
-                                                <h5 className="font-bold text-white truncate">다시보기</h5>
+                                                <h5 className="font-bold text-white truncate">{vod.title || `다시보기 #${vod.replayId}`}</h5>
                                                 <p className="text-white/40 text-xs mt-1">{vod.publishedAt ? new Date(vod.publishedAt).toLocaleDateString("ko-KR") : ""}</p>
                                             </Link>
                                         ))}

--- a/frontend/app/posts/[id]/page.js
+++ b/frontend/app/posts/[id]/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useCallback, Suspense } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo, Suspense } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { MOCK_POSTS, MOCK_ARTISTS } from "@/lib/mockData";
@@ -54,6 +54,114 @@ function enhanceComment(c) {
     isLiked: c.isLiked ?? false,
     isEdited: c.isEdited ?? false,
   };
+}
+
+function AttachmentCarousel({ attachments }) {
+  const scrollRef = useRef(null);
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const count = attachments.length;
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const idx = Math.round(el.scrollLeft / el.clientWidth);
+    setCurrentIdx(Math.min(Math.max(idx, 0), count - 1));
+  }, [count]);
+
+  const goTo = useCallback((idx) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ left: el.clientWidth * idx, behavior: "smooth" });
+  }, []);
+
+  if (count === 1) {
+    const att = attachments[0];
+    const isVideo = att.contentType?.startsWith("video/") || att.category === "POST_VIDEO";
+    return (
+      <div className="mt-6 rounded-2xl overflow-hidden border border-white/[0.06] bg-black/20">
+        {isVideo ? (
+          <video src={att.url} controls preload="metadata" className="w-full max-h-[480px] object-contain" />
+        ) : (
+          <img
+            src={att.url}
+            alt="첨부"
+            className="w-full max-h-[480px] object-contain cursor-pointer"
+            onClick={() => window.open(att.url, "_blank")}
+          />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-6 relative group">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex overflow-x-auto snap-x snap-mandatory scrollbar-hide rounded-2xl border border-white/[0.06]"
+        style={{ scrollbarWidth: "none", msOverflowStyle: "none", WebkitOverflowScrolling: "touch" }}
+      >
+        {attachments.map((att, idx) => {
+          const isVideo = att.contentType?.startsWith("video/") || att.category === "POST_VIDEO";
+          return (
+            <div
+              key={att.mediaAssetId || idx}
+              className="w-full shrink-0 snap-center bg-black/20"
+            >
+              {isVideo ? (
+                <video src={att.url} controls preload="metadata" className="w-full h-[400px] object-contain" />
+              ) : (
+                <img
+                  src={att.url}
+                  alt={`첨부 ${idx + 1}`}
+                  className="w-full h-[400px] object-contain cursor-pointer"
+                  onClick={() => window.open(att.url, "_blank")}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {currentIdx > 0 && (
+        <button
+          type="button"
+          onClick={() => goTo(currentIdx - 1)}
+          className="absolute left-3 top-1/2 -translate-y-1/2 size-10 rounded-full bg-black/60 backdrop-blur-sm text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/80"
+        >
+          <span className="material-symbols-outlined text-lg">chevron_left</span>
+        </button>
+      )}
+      {currentIdx < count - 1 && (
+        <button
+          type="button"
+          onClick={() => goTo(currentIdx + 1)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 size-10 rounded-full bg-black/60 backdrop-blur-sm text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/80"
+        >
+          <span className="material-symbols-outlined text-lg">chevron_right</span>
+        </button>
+      )}
+
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-1.5">
+        {attachments.map((_, idx) => (
+          <button
+            key={idx}
+            type="button"
+            onClick={() => goTo(idx)}
+            className={`rounded-full transition-all ${
+              idx === currentIdx
+                ? "w-6 h-2 bg-white"
+                : "size-2 bg-white/40 hover:bg-white/60"
+            }`}
+          />
+        ))}
+      </div>
+
+      <span className="absolute top-4 right-4 px-2.5 py-1 rounded-lg bg-black/60 backdrop-blur-sm text-white text-xs font-bold">
+        {currentIdx + 1} / {count}
+      </span>
+    </div>
+  );
 }
 
 function PostDetailContent({ id }) {
@@ -760,35 +868,7 @@ function PostDetailContent({ id }) {
                   </p>
                 </div>
                 {post.attachments?.length > 0 && (
-                  <div className={`mt-6 gap-3 ${
-                    post.attachments.length === 1
-                      ? "flex"
-                      : "grid grid-cols-2"
-                  }`}>
-                    {post.attachments.map((att, idx) => {
-                      const isVideo = att.contentType?.startsWith("video/") ||
-                        att.category === "POST_VIDEO";
-                      return isVideo ? (
-                        <div key={att.mediaAssetId || idx} className="rounded-2xl overflow-hidden bg-black border border-white/[0.06]">
-                          <video
-                            src={att.url}
-                            controls
-                            preload="metadata"
-                            className="w-full max-h-80 object-contain"
-                          />
-                        </div>
-                      ) : (
-                        <div key={att.mediaAssetId || idx} className="rounded-2xl overflow-hidden border border-white/[0.06] bg-black/20">
-                          <img
-                            src={att.url}
-                            alt={`첨부 ${idx + 1}`}
-                            className="w-full max-h-80 object-contain cursor-pointer hover:scale-[1.02] transition-transform"
-                            onClick={() => window.open(att.url, "_blank")}
-                          />
-                        </div>
-                      );
-                    })}
-                  </div>
+                  <AttachmentCarousel attachments={post.attachments} />
                 )}
               </>
             )}

--- a/frontend/app/replay/[replayId]/page.js
+++ b/frontend/app/replay/[replayId]/page.js
@@ -92,52 +92,98 @@ export default function ReplayWatchPage({ params }) {
     );
   }
 
+  const isPaidError = error?.includes("구독") || error?.includes("SUBSCRIPTION");
+  const backHref = replay?.artistId ? `/artists/${replay.artistId}?tab=LIVE` : "/";
+
   if (error && !playbackUrl) {
     return (
-      <div className="min-h-screen bg-black flex flex-col items-center justify-center gap-4 p-6">
-        <p className="text-red-400 text-center">{error}</p>
-        <Link href="/" className="text-white/70 hover:text-white underline">
-          홈으로
-        </Link>
+      <div className="min-h-screen bg-[#0d0b15] flex flex-col items-center justify-center gap-6 p-6">
+        {isPaidError ? (
+          <div className="text-center space-y-4 max-w-md">
+            <span className="material-symbols-outlined text-6xl text-violet-400/60 fill-icon">lock</span>
+            <h2 className="text-xl font-bold text-white">멤버십 전용 다시보기</h2>
+            <p className="text-white/55 text-sm leading-relaxed">
+              이 다시보기는 유료 멤버십 회원만 시청할 수 있습니다.<br />
+              멤버십에 가입하면 모든 프리미엄 콘텐츠를 즐길 수 있어요.
+            </p>
+            <Link
+              href={backHref}
+              className="inline-flex items-center gap-2 px-6 py-3 bg-violet-500/90 text-white rounded-full font-bold text-sm hover:brightness-110 transition-all"
+            >
+              아티스트 페이지로 이동
+            </Link>
+          </div>
+        ) : (
+          <div className="text-center space-y-4">
+            <span className="material-symbols-outlined text-5xl text-red-400/60">error</span>
+            <p className="text-red-400">{error}</p>
+            <Link href={backHref} className="text-white/70 hover:text-white underline text-sm">
+              돌아가기
+            </Link>
+          </div>
+        )}
       </div>
     );
   }
 
+  const displayTitle = replay?.title || (replay?.replayId ? `다시보기 #${replay.replayId}` : "다시보기");
+  const publishedDate = replay?.publishedAt
+    ? new Date(replay.publishedAt).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" })
+    : null;
+
   return (
-    <div className="min-h-screen bg-black flex flex-col">
-      <div className="flex-1 flex flex-col items-center p-4">
-        <div className="w-full max-w-4xl">
-          {replay?.thumbnailUrl && !playbackUrl && (
-            <div className="w-full aspect-video rounded-lg overflow-hidden bg-black/40">
-              <img src={replay.thumbnailUrl} alt="" className="w-full h-full object-cover" />
-            </div>
-          )}
-          {playbackUrl && (
-            <video
-              ref={videoRef}
-              src={videoSrc}
-              controls
-              className="w-full aspect-video bg-black rounded-lg"
-              crossOrigin="use-credentials"
-              playsInline
-            />
-          )}
-          {replay && (
-            <div className="mt-4 text-white/80">
-              <h1 className="text-xl font-bold truncate">
-                다시보기 #{replay.replayId}
-              </h1>
-              <p className="text-sm text-white/55 mt-1">
-                {replay.accessType} · {replay.status}
-              </p>
-            </div>
-          )}
+    <div className="min-h-screen bg-[#0d0b15] flex flex-col">
+      <div className="flex-1 flex flex-col items-center p-4 sm:p-8">
+        <div className="w-full max-w-4xl space-y-6">
           <Link
-            href="/"
-            className="inline-block mt-6 text-white/70 hover:text-white underline"
+            href={backHref}
+            className="inline-flex items-center gap-1.5 text-white/50 hover:text-violet-300 font-bold text-xs uppercase tracking-widest transition-colors"
           >
-            ← 홈으로
+            <span className="material-symbols-outlined text-sm">arrow_back</span>
+            돌아가기
           </Link>
+
+          <div className="rounded-2xl overflow-hidden border border-white/[0.08] bg-black">
+            {replay?.thumbnailUrl && !playbackUrl && (
+              <div className="w-full aspect-video relative">
+                <img src={replay.thumbnailUrl} alt="" className="w-full h-full object-cover" />
+                <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                  <div className="size-16 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center">
+                    <span className="material-symbols-outlined text-white text-4xl fill-icon">play_arrow</span>
+                  </div>
+                </div>
+              </div>
+            )}
+            {playbackUrl && (
+              <video
+                ref={videoRef}
+                src={videoSrc}
+                controls
+                autoPlay
+                className="w-full aspect-video bg-black"
+                crossOrigin="use-credentials"
+                playsInline
+              />
+            )}
+          </div>
+
+          {replay && (
+            <div className="space-y-2">
+              <h1 className="text-2xl font-extrabold text-white">
+                {displayTitle}
+              </h1>
+              <div className="flex items-center gap-3 text-sm text-white/50">
+                {publishedDate && <span>{publishedDate}</span>}
+                <span className={`px-2 py-0.5 rounded-md text-[10px] font-black uppercase tracking-widest ${
+                  replay.accessType === "PAID"
+                    ? "bg-violet-500/20 text-violet-300 border border-violet-400/30"
+                    : "bg-white/[0.06] text-white/50"
+                }`}>
+                  {replay.accessType === "PAID" ? "멤버십" : "무료"}
+                </span>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/components/PostCard.jsx
+++ b/frontend/components/PostCard.jsx
@@ -106,8 +106,8 @@ export default function PostCard({
         <>
           <p className="text-white/80 text-lg leading-relaxed mb-6 font-normal whitespace-pre-wrap">{post.content}</p>
           {post.image && (
-            <div className="relative">
-              <img src={post.image} className="rounded-2xl w-full border border-white/[0.06] object-cover max-h-80" alt="" />
+            <div className="relative rounded-2xl overflow-hidden border border-white/[0.06] bg-black/20">
+              <img src={post.image} className="w-full h-48 object-cover" alt="" />
               {post.attachmentCount > 1 && (
                 <span className="absolute top-3 right-3 px-2 py-0.5 rounded-lg bg-black/60 backdrop-blur-sm text-white text-xs font-bold">
                   +{post.attachmentCount - 1}


### PR DESCRIPTION
1. PostCard 미리보기 이미지 크기 축소
- 변경 파일: frontend/components/PostCard.jsx
- 기존: max-h-80 (320px) + object-cover → 이미지가 커서 잘림
- 변경: 고정 높이 h-48 (192px) + object-cover + rounded-2xl overflow-hidden으로 깔끔하게 컨테이너 안에 표시

2. 포스트 상세보기 — 인스타 스타일 캐러셀
- 변경 파일: frontend/app/posts/[id]/page.js
- 기존 2열 그리드를 제거하고 AttachmentCarousel 컴포넌트를 추가했습니다.
- CSS scroll-snap으로 구현 (외부 라이브러리 불필요)
- 좌우 화살표 버튼 (hover 시 나타남)
- 하단 도트 인디케이터 (현재 위치 표시, 클릭으로 이동)
- 우상단 1/3 형태 카운터
- 첨부파일 1개일 때는 캐러셀 없이 단일 표시
- 이미지 클릭 시 새 탭에서 원본 보기
- 영상은 <video> + controls

artistId 노출 제거
- 발행 페이지에서 editable artistId 입력 필드 삭제. JWT에서 자동 감지된 값만 사용

IVS 발행 폼
- 제목 입력 placeholder 추가, 접근 타입 한글화 ("무료 (전체 공개)" / "유료 (멤버십 전용)")

수동 업로드 폼
- 제목 입력 필드 추가, API 호출 시 title 전송, 접근 타입 한글화

재생 페이지 UI
- 제목 표시 (없으면 "다시보기 #ID"), 발행일 표시, 멤버십/무료 뱃지, 뒤로가기 아티스트 페이지 연결, 유료 접근 실패 시 전용 
안내 화면 (구독 유도)

팬 다시보기 목록
- 제목 표시, 썸네일 없을 때 picsum.photos → 자체 아이콘 placeholder, 유료 콘텐츠 "멤버십" 뱃지, hover 재생 버튼 개선

아티스트 콘솔 메인
- "다시보기" 버튼 → "다시보기 관리" + /artist-console/live로 링크 수정 (기존: 개별 라이브 상세 페이지)