### PR TITLE
fix: 포스트 첨부파일있으면 댓글 안보이는거 수정 완료

### DIFF
--- a/frontend/app/artist-console/page.js
+++ b/frontend/app/artist-console/page.js
@@ -1121,9 +1121,9 @@ export default function ArtistConsolePage() {
 
             {/* 새 글 작성 모달 */}
             {showCreateModal && (
-                <div className="fixed inset-0 z-[100] flex items-center justify-center p-6 bg-black/60 backdrop-blur-sm">
-                    <Surface variant="primary" className="w-full max-w-2xl p-10">
-                        <div className="flex justify-between items-center mb-6">
+                <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6 bg-black/60 backdrop-blur-sm">
+                    <Surface variant="primary" className="w-full max-w-2xl max-h-[90vh] overflow-y-auto custom-scrollbar p-6 sm:p-10">
+                        <div className="flex justify-between items-center mb-6 sticky top-0 z-10">
                             <h3 className="text-xl font-semibold text-white">새 글 작성</h3>
                             <button
                                 type="button"

--- a/frontend/app/artists/[id]/page.js
+++ b/frontend/app/artists/[id]/page.js
@@ -1262,9 +1262,9 @@ function ArtistDetailPageInner({ paramsId }) {
 
             {/* 팬 포스트 작성 모달 */}
             {showCreateModal && (
-                <div className="fixed inset-0 z-[100] flex items-center justify-center p-6 bg-black/80 backdrop-blur-sm">
-                    <Surface className="w-full max-w-xl p-8">
-                        <div className="flex justify-between items-center mb-6">
+                <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6 bg-black/80 backdrop-blur-sm">
+                    <Surface className="w-full max-w-xl max-h-[90vh] overflow-y-auto custom-scrollbar p-6 sm:p-8">
+                        <div className="flex justify-between items-center mb-6 sticky top-0 z-10">
                             <h3 className="text-xl font-bold text-white">포스트 작성</h3>
                             <button onClick={closeFanPostModal} className="text-white/50 hover:text-white">
                                 <span className="material-symbols-outlined">close</span>

--- a/frontend/app/posts/[id]/page.js
+++ b/frontend/app/posts/[id]/page.js
@@ -815,16 +815,17 @@ function PostDetailContent({ id }) {
     : "아티스트 페이지로 돌아가기";
 
   return (
-    <div className="max-w-6xl mx-auto p-8 flex flex-col lg:flex-row gap-8 min-h-full">
-      <div className="flex-1 space-y-6">
+    <div className="max-w-6xl mx-auto p-4 sm:p-8 flex flex-col md:flex-row gap-6 h-[calc(100vh-80px)]">
+      <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
         <Link
           href={backHref}
-          className="flex items-center gap-2 text-white/55 hover:text-violet-300 font-bold text-xs uppercase tracking-widest transition-all mb-4"
+          className="flex items-center gap-2 text-white/55 hover:text-violet-300 font-bold text-xs uppercase tracking-widest transition-all mb-4 shrink-0"
         >
           <span className="material-symbols-outlined text-[18px]">arrow_back</span>
           {backLabel}
         </Link>
 
+        <div className="flex-1 overflow-y-auto custom-scrollbar pr-1">
         <article className="bg-[#201a33] rounded-[2.5rem] border border-white/[0.08] overflow-hidden relative">
           {post.isMembershipOnly && (
             <span className="absolute top-6 right-6 z-10 px-3 py-1.5 rounded-lg bg-violet-500/25 text-violet-300 text-xs font-black uppercase tracking-widest border border-violet-400/30">
@@ -902,11 +903,12 @@ function PostDetailContent({ id }) {
             </div>
           </div>
         </article>
+        </div>
       </div>
 
       {post != null && !post.isNotice && (
-      <aside className="w-full lg:w-96 flex flex-col gap-6 shrink-0">
-        <div className="bg-[#201a33] rounded-3xl border border-white/[0.08] flex flex-col h-[calc(100vh-160px)] sticky top-24">
+      <aside className="w-full md:w-96 shrink-0 min-h-0">
+        <div className="bg-[#201a33] rounded-3xl border border-white/[0.08] flex flex-col h-full">
           <div className="p-6 border-b border-white/[0.06] flex items-center justify-between">
             <h3 className="font-extrabold text-white">댓글</h3>
             <span className="text-xs font-bold text-white/55 uppercase tracking-widest">


### PR DESCRIPTION
전체 컨테이너: min-h-full → h-[calc(100vh-80px)] 고정 높이로 변경
왼쪽 포스트 영역: overflow-y-auto로 독립 스크롤 추가 → 캐러셀이 아무리 길어도 댓글 영역에 영향 없음
2단 레이아웃 기준: lg:flex-row → md:flex-row로 더 일찍 적용 (768px부터)
댓글 사이드바: sticky 제거, 대신 부모의 고정 높이 안에서 h-full로 채움 → 항상 포스트 옆에 고정
이제 포스트에 첨부파일이 있어도 댓글이 항상 오른편에 표시되고, 포스트 내용만 자체적으로 스크롤됩니다.

수정 내용 (아티스트 콘솔 + 팬 페이지 모달 모두):
max-h-[90vh] 추가 → 모달이 뷰포트의 90%를 넘지 않음
overflow-y-auto 추가 → 내용이 넘치면 모달 안에서 스크롤
custom-scrollbar → 깔끔한 스크롤바 스타일
모달 헤더(제목 + 닫기 버튼)에 sticky top-0 z-10 → 스크롤해도 헤더가 고정되어 항상 닫기 가능
이제 첨부파일이 5개 꽉 차도 모달 안에서 스크롤하면서 모든 버튼에 접근할 수 있습니다.